### PR TITLE
Card sounds, externalize strings & some fixes

### DIFF
--- a/core/src/css/component/collection/full-card.component.scss
+++ b/core/src/css/component/collection/full-card.component.scss
@@ -87,7 +87,6 @@
 				}
 
 				.label {
-					text-transform: capitalize;
 				}
 			}
 

--- a/core/src/css/component/decktracker/copy-deckstring.component.scss
+++ b/core/src/css/component/decktracker/copy-deckstring.component.scss
@@ -20,9 +20,10 @@
 	&:hover {
 		--icon-color: var(--color-1);
 	}
+	.message {
+		font-size: 13px;
+		margin-left: 10px;
+	}
 }
 
-.message {
-	font-size: 13px;
-	margin-left: 10px;
-}
+

--- a/core/src/css/component/decktracker/main/decktracker-stats-for-replays.component.scss
+++ b/core/src/css/component/decktracker/main/decktracker-stats-for-replays.component.scss
@@ -15,6 +15,7 @@
 		display: flex;
 		flex-direction: column;
 		width: 155px;
+		height: 75px;
 		align-items: center;
 		justify-content: center;
 		margin-right: 15px;

--- a/core/src/css/component/mercenaries/desktop/mercenaries-personal-hero-stat.component.scss
+++ b/core/src/css/component/mercenaries/desktop/mercenaries-personal-hero-stat.component.scss
@@ -104,6 +104,7 @@
 		width: 60px;
 		margin-right: 20px;
 		flex-shrink: 0;
+		text-align: center;
 
 		::ng-deep progress-bar {
 			.current {

--- a/core/src/js/components/battlegrounds/battles/bgs-simulator-hero-selection.component.ts
+++ b/core/src/js/components/battlegrounds/battles/bgs-simulator-hero-selection.component.ts
@@ -240,6 +240,7 @@ export class BgsSimulatorHeroSelectionComponent
 					.replace(/<i>/g, '')
 					.replace(/<\/i>/g, '')
 					.replace(/<br>/g, '')
+					.replace(/\$/g, '')
 					.replace(/Passive\. /g, '')
 					.replace(/Passive /g, '')
 					.replace(/Passive/g, '')

--- a/core/src/js/components/battlegrounds/desktop/categories/hero-details/bgs-hero-detailed-stats.component.ts
+++ b/core/src/js/components/battlegrounds/desktop/categories/hero-details/bgs-hero-detailed-stats.component.ts
@@ -51,7 +51,7 @@ import { AbstractSubscriptionComponent } from '../../../../abstract-subscription
 						[owTranslate]="'app.battlegrounds.personal-stats.hero-details.stats.top-4'"
 					></div>
 					<div class="values">
-						<div class="my-value">{{ buildValue(stats.playerTop4, 1) }}</div>
+						<div class="my-value">{{ buildValue(stats.playerTop4, 1) }}%</div>
 						<bgs-global-value [value]="buildValue(stats.top4, 1) + '%'"></bgs-global-value>
 					</div>
 				</div>
@@ -170,7 +170,7 @@ export class BgsHeroDetailedStatsComponent extends AbstractSubscriptionComponent
 		`../../../../../../css/component/battlegrounds/desktop/categories/hero-details/bgs-hero-detailed-stats.component.scss`,
 	],
 	template: `
-		<div class="global-value" helpTooltip="Average value for the community">
+		<div class="global-value" helpTooltip="'app.battlegrounds.personal-stats.hero-details.stats.community-value-tooltip' | owTranslate">
 			<div class="global-icon">
 				<svg class="svg-icon-fill">
 					<use xlink:href="assets/svg/sprite.svg#global" />

--- a/core/src/js/components/battlegrounds/post-match/stat-cell.component.ts
+++ b/core/src/js/components/battlegrounds/post-match/stat-cell.component.ts
@@ -29,13 +29,16 @@ declare let amplitude: any;
 			<div class="hero">
 				<img
 					*ngIf="_heroCardId"
-					[helpTooltip]="'Best stat unlocked with ' + getCardName(_heroCardId)"
+					[helpTooltip]="'app.battlegrounds.personal-stats.records.rows.best-stat-hero'
+							| owTranslate: { heroName: getCardName(_heroCardId) }"
 					[src]="heroImage"
 					class="portrait"
 				/>
 				<img
 					*ngIf="heroIcon"
-					[helpTooltip]="'Best stat unlocked with ' + getCardName(heroIcon)"
+					[helpTooltip]="'app.battlegrounds.personal-stats.records.rows.best-stat-hero'
+							| owTranslate: { heroName: getCardName(heroIcon) }"
+				
 					[src]="'https://static.zerotoheroes.com/hearthstone/cardart/256x/' + heroIcon + '.jpg'"
 					class="portrait"
 				/>
@@ -44,7 +47,7 @@ declare let amplitude: any;
 				class="replay"
 				*ngIf="reviewId"
 				(click)="showReplay()"
-				helpTooltip="Watch the replay where this value was obtained"
+				helpTooltip="'app.battlegrounds.personal-stats.records.rows.watch-replay-tooltip' | owTranslate"
 			>
 				<div class="watch-icon">
 					<svg class="svg-icon-fill">

--- a/core/src/js/components/collection/full-card.component.ts
+++ b/core/src/js/components/collection/full-card.component.ts
@@ -257,6 +257,11 @@ export class FullCardComponent {
 			category: 'emote',
 		},
 		{
+			regex: /.*WOW.*/g,
+			value: this.i18n.translateString('app.collection.card-details.sounds.effect.wow'),
+			category: 'emote',
+		},
+		{
 			regex: /.*CONCEDE.*/g,
 			value: this.i18n.translateString('app.collection.card-details.sounds.effect.concede'),
 			category: 'emote',
@@ -267,32 +272,32 @@ export class FullCardComponent {
 			category: 'emote',
 		},
 		{
-			regex: /.*TIMER.*/g,
+			regex: /.*TIMER?.*/g,
 			value: this.i18n.translateString('app.collection.card-details.sounds.effect.timer'),
 			category: 'emote',
 		},
 		{
-			regex: /.*THINK1.*/g,
+			regex: /.*THINK(?:ING_0)?1.*/g,
 			value: this.i18n.translateString('app.collection.card-details.sounds.effect.think-1'),
 			category: 'emote',
 		},
 		{
-			regex: /.*THINK2.*/g,
+			regex: /.*THINK(?:ING_0)?2.*/g,
 			value: this.i18n.translateString('app.collection.card-details.sounds.effect.think-2'),
 			category: 'emote',
 		},
 		{
-			regex: /.*THINK3.*/g,
+			regex: /.*THINK(?:ING_0)?3.*/g,
 			value: this.i18n.translateString('app.collection.card-details.sounds.effect.think-3'),
 			category: 'emote',
 		},
 		{
-			regex: /.*LOW_CARDS.*/g,
+			regex: /.*LOW_?CARDS.*/g,
 			value: this.i18n.translateString('app.collection.card-details.sounds.effect.low-cards'),
 			category: 'emote',
 		},
 		{
-			regex: /.*NO_CARDS.*/g,
+			regex: /.*NO_?CARDS.*/g,
 			value: this.i18n.translateString('app.collection.card-details.sounds.effect.no-cards'),
 			category: 'emote',
 		},
@@ -327,7 +332,7 @@ export class FullCardComponent {
 			category: 'error',
 		},
 		{
-			regex: /.*ERROR_JUST_PLAYED.*/g,
+			regex: /.*ERROR_JUST_PLAYED.*|.*SUMMON_SICKNESS.*/g,
 			value: this.i18n.translateString('app.collection.card-details.sounds.effect.error-just-played'),
 			category: 'error',
 		},
@@ -367,18 +372,23 @@ export class FullCardComponent {
 			category: 'error',
 		},
 		{
-			regex: /.*EVENT_LUNAR_NEW_YEAR.*/g,
-			value: this.i18n.translateString('app.collection.card-details.sounds.effect.lunar-new-year'),
-			category: 'event',
-		},
-		{
 			regex: /.*WINTERVEIL_GREETINGS.*/g,
 			value: this.i18n.translateString('app.collection.card-details.sounds.effect.winterveil-greetings'),
 			category: 'event',
 		},
 		{
+			regex: /.*HAPPY_HOLIDAYS.*/g,
+			value: this.i18n.translateString('app.collection.card-details.sounds.effect.happy-holidays'),
+			category: 'event',
+		},
+		{
+			regex: /.*EVENT_LUNAR_NEW_YEAR.*|.*HAPPY_NEW_YEAR_LUNAR.*/g,
+			value: this.i18n.translateString('app.collection.card-details.sounds.effect.lunar-new-year'),
+			category: 'event',
+		},
+		{
 			regex: /.*HAPPY_NEW_YEAR.*/g,
-			value: this.i18n.translateString('app.collection.card-details.sounds.effect.happy-new-year-20'),
+			value: this.i18n.translateString('app.collection.card-details.sounds.effect.happy-new-year'),
 			category: 'event',
 		},
 		{
@@ -392,7 +402,7 @@ export class FullCardComponent {
 			category: 'event',
 		},
 		{
-			regex: /.*HALLOWS_END.*/g,
+			regex: /.*HALLOWS_END.*|.*HAPPY_HALLOWEEN.*/g,
 			value: this.i18n.translateString('app.collection.card-details.sounds.effect.hallows-end'),
 			category: 'event',
 		},
@@ -400,6 +410,11 @@ export class FullCardComponent {
 			regex: /.*NOBLEGARDEN.*/g,
 			value: this.i18n.translateString('app.collection.card-details.sounds.effect.noblegarden'),
 			category: 'event',
+		},
+		{
+			regex: /.*PICKED.*/g,
+			value: this.i18n.translateString('app.collection.card-details.sounds.effect.picked'),
+			category: 'other',
 		},
 	];
 

--- a/core/src/js/components/collection/full-card.component.ts
+++ b/core/src/js/components/collection/full-card.component.ts
@@ -119,7 +119,7 @@ export class FullCardComponent {
 			card.playerClass !== 'Neutral'
 				? formatClass(card.playerClass, this.i18n)
 				: card.classes?.length
-				? card.classes.map((playerClass) => formatClass(card.playerClass, this.i18n)).join(', ')
+				? card.classes.map((playerClass) => formatClass(playerClass, this.i18n)).join(', ')
 				: formatClass('all', this.i18n);
 		this.type = card.type;
 		this.set = this.cards.setName(card.set);
@@ -377,7 +377,7 @@ export class FullCardComponent {
 			category: 'event',
 		},
 		{
-			regex: /.*HAPPY_NEW_YEAR_20.*/g,
+			regex: /.*HAPPY_NEW_YEAR.*/g,
 			value: this.i18n.translateString('app.collection.card-details.sounds.effect.happy-new-year-20'),
 			category: 'event',
 		},
@@ -469,7 +469,7 @@ export class FullCardComponent {
 	}
 
 	private transformFlavor(flavor: string): string {
-		const result = flavor.replace(/\n/g, '<br>').replace(/<i>/g, '').replace(/<\/i>/g, '').replace(/<br>/g, ' ');
+		const result = flavor.replace(/\n/g, '<br>').replace(/<i>/g, '').replace(/<\/i>/g, '').replace(/<br>/g, ' ').replace(/[x]/g, '');
 		return result;
 	}
 }

--- a/core/src/js/components/collection/pack-stats.component.ts
+++ b/core/src/js/components/collection/pack-stats.component.ts
@@ -219,9 +219,7 @@ const NON_BUYABLE_BOOSTER_IDS = [
 	BoosterType.STANDARD_SHAMAN,
 	BoosterType.STANDARD_WARRIOR,
 	BoosterType.STANDARD_WARLOCK,
-	BoosterType.STANDARD_BUNDLE,
-	BoosterType.GOLDEN_STANDARD_BUNDLE,
-	BoosterType.WILD_PACK,
+	BoosterType.GOLDEN_STANDARD_BUNDLE
 ];
 
 interface InternalPackGroup {

--- a/core/src/js/components/decktracker/copy-deckstring.component.ts
+++ b/core/src/js/components/decktracker/copy-deckstring.component.ts
@@ -24,8 +24,9 @@ declare let amplitude;
 			<svg class="svg-icon-fill">
 				<use xlink:href="assets/svg/sprite.svg#copy_deckstring" />
 			</svg>
+		
+			<div class="message" *ngIf="!showTooltip || title">{{ copyText || title }}</div>
 		</div>
-		<div class="message" *ngIf="!showTooltip || title">{{ copyText || title }}</div>
 	`,
 	changeDetection: ChangeDetectionStrategy.OnPush,
 })

--- a/core/src/js/components/decktracker/main/deck-matchup-info.component.ts
+++ b/core/src/js/components/decktracker/main/deck-matchup-info.component.ts
@@ -126,11 +126,15 @@ export class DeckMatchupInfoComponent {
 			this._matchup.totalWinsFirst != null && this._matchup.totalGamesFirst
 				? (100 * this._matchup.totalWinsFirst) / this._matchup.totalGamesFirst
 				: null;
-		this.winrateFirstTooltip = `Played ${this._matchup.totalGamesFirst} matches going first`;
+		this.winrateFirstTooltip = this.i18n.translateString('app.decktracker.matchup-info.matches-going-first', {
+						totalMatches: this._matchup.totalGamesFirst,
+					});
 		this.winrateCoin =
 			this._matchup.totalWinsCoin != null && this._matchup.totalGamesCoin
 				? (100 * this._matchup.totalWinsCoin) / this._matchup.totalGamesCoin
 				: null;
-		this.winrateCoinTooltip = `Played ${this._matchup.totalGamesCoin} matches going second`;
+		this.winrateCoinTooltip = this.i18n.translateString('app.decktracker.matchup-info.matches-going-second', {
+						totalMatches: this._matchup.totalGamesCoin,
+					});
 	}
 }

--- a/core/src/js/components/decktracker/main/deck-winrate-matrix.component.ts
+++ b/core/src/js/components/decktracker/main/deck-winrate-matrix.component.ts
@@ -25,7 +25,7 @@ import { InputPieChartData, InputPieChartOptions } from '../../common/chart/inpu
 	],
 	template: `
 		<div class="opponents-popularity">
-			<div class="title">Opponent class breakdown</div>
+			<div class="title"> [owTranslate]="'app.decktracker.matchup-info.opponents-popularity-header'" </div>
 			<pie-chart class="opponents-popularity-chart" [data]="pieChartData" [options]="pieChartOptions"></pie-chart>
 		</div>
 		<div class="deck-winrate-matrix">
@@ -75,7 +75,7 @@ import { InputPieChartData, InputPieChartOptions } from '../../common/chart/inpu
 						(mousedown)="reset()"
 						[helpTooltip]="'app.decktracker.matchup-info.reset-button-tooltip' | owTranslate"
 					>
-						<span>{{ resetText }}</span>
+						<span>{{ [owTranslate]="'app.decktracker.matchup-info.reset-button-label'" }}</span>
 					</button>
 					<div
 						class="confirmation"
@@ -92,7 +92,7 @@ import { InputPieChartData, InputPieChartOptions } from '../../common/chart/inpu
 						(onConfirm)="deleteDeck()"
 						[helpTooltip]="'app.decktracker.matchup-info.delete-tooltip' | owTranslate"
 					>
-						<span>{{ deleteText }}</span>
+						<span>{{ [owTranslate]="'app.decktracker.matchup-info.delete-button-label'" }}</span>
 					</button>
 				</div>
 			</div>
@@ -117,8 +117,6 @@ export class DeckWinrateMatrixComponent implements AfterViewInit {
 	pieChartData: readonly InputPieChartData[];
 	pieChartOptions: InputPieChartOptions;
 
-	resetText = 'Reset stats';
-	deleteText = 'Delete deck';
 	confirmationShown = false;
 	showResetConfirmationText = false;
 

--- a/core/src/js/components/duels/desktop/duels-hero-stat-vignette.component.ts
+++ b/core/src/js/components/duels/desktop/duels-hero-stat-vignette.component.ts
@@ -17,7 +17,7 @@ import { SimpleBarChartData } from '../../common/chart/simple-bar-chart-data';
 		<div class="duels-hero-stat-vignette" [ngClass]="{ 'unused': playerGamesPlayed === 0 }">
 			<div class="box-side">
 				<div class="name-container">
-					<div class="name" [helpTooltip]="playerClassLoc + ' - ' + name">{{ name }}</div>
+					<div class="name" [helpTooltip]="name + ' (' + playerClassLoc + ')'">{{ name }}</div>
 					<div class="info" [helpTooltip]="numberOfGamesTooltip">
 						<svg>
 							<use xlink:href="assets/svg/sprite.svg#info" />
@@ -76,7 +76,7 @@ export class DuelsHeroStatVignetteComponent {
 		const isNeutralHero =
 			value.cardId.startsWith(CardIds.VanndarStormpikeTavernBrawl) ||
 			value.cardId.startsWith(CardIds.DrektharTavernBrawl);
-		this.name = isNeutralHero ? `${this.playerClassLoc} ${card?.name}` : card?.name;
+		this.name = card?.name;
 		this.secondaryClassIcon = isNeutralHero
 			? `https://static.zerotoheroes.com/hearthstone/asset/firestone/images/deck/classes/${card?.playerClass?.toLowerCase()}.png`
 			: null;

--- a/core/src/js/components/mercenaries/desktop/mercenaries-personal-hero-stat.component.ts
+++ b/core/src/js/components/mercenaries/desktop/mercenaries-personal-hero-stat.component.ts
@@ -301,7 +301,7 @@ export class MercenariesPersonalHeroStatComponent {
 		);
 		return `
 			<div class="container">
-				<div class="header">Where to farm coins</div>
+				<div class="header"> "'mercenaries.hero-stats.bounties-to-farm' | owTranslate" </div>
 				${bounties.join('')}
 			</div>
 		`;

--- a/core/src/js/components/mercenaries/desktop/unused_mercenaries-compositions-stats.component.ts
+++ b/core/src/js/components/mercenaries/desktop/unused_mercenaries-compositions-stats.component.ts
@@ -30,10 +30,10 @@ import { MercenaryCompositionInfo, MercenaryInfo } from './mercenary-info';
 		>
 			<ng-container *ngIf="stats$ | async as stats; else emptyState">
 				<div class="header">
-					<div class="starter">Team</div>
+					<div class="starter"> "'mercenaries.teams.team' | owTranslate" </div>
 					<!-- <div class="bench" helpTooltip="An example of a possible bench for this composition">Bench</div> -->
-					<div class="stat winrate">Global winrate</div>
-					<div class="stat matches">Total matches</div>
+					<div class="stat winrate"> "'mercenaries.teams.global-winrate' | owTranslate" </div>
+					<div class="stat matches"> "'mercenaries.teams.total-matches' | owTranslate" </div>
 				</div>
 				<mercenaries-composition-stat
 					*ngFor="let stat of stats; trackBy: trackByFn"

--- a/core/src/js/components/overlays/duels-ooc/duels-deck-widget.component.ts
+++ b/core/src/js/components/overlays/duels-ooc/duels-deck-widget.component.ts
@@ -86,7 +86,7 @@ export class DuelsDeckWidgetComponent {
 			value.type === 'duels'
 				? 'assets/images/deck/ranks/casual_duels.png'
 				: 'assets/images/deck/ranks/heroic_duels.png';
-		this.rankText = `${value.mmr}`;
+		this.rankText = value.mmr == null ? '0' :`${value.mmr}`;
 		this.treasureCardIds = value.treasureCardIds ?? [];
 		this.wins = value.wins;
 		this.losses = value.losses;

--- a/core/src/js/components/settings/decktracker/settings-decktracker-global.ts
+++ b/core/src/js/components/settings/decktracker/settings-decktracker-global.ts
@@ -101,7 +101,7 @@ import { Knob } from '../preference-slider.component';
 			<div class="reset-container">
 				<button
 					(mousedown)="reset()"
-					helpTooltip="'settings.decktracker.global.reset-button-tooltip' | owTranslate"
+					[helpTooltip]="'settings.decktracker.global.reset-button-tooltip' | owTranslate"
 				>
 					<span>{{ resetText }}</span>
 				</button>


### PR DESCRIPTION
Removed capitalization of sound names because it looks pretty bad in Non-English languages
Added new types of card sounds
Made the text "Copy deck code" also clickable
Standard and Wild packs added to the Main sets					
LOC: externalize strings for BG desktop, community value tooltip, labels in deck-winrate-matrix.component.ts, tooltips in deck-matchup-info.component.ts
Tried to fix multi-class cards bug