### PR TITLE
Some cosmetic improvements

### DIFF
--- a/core/src/css/component/collection/full-card.component.scss
+++ b/core/src/css/component/collection/full-card.component.scss
@@ -87,7 +87,6 @@
 				}
 
 				.label {
-					text-transform: capitalize;
 				}
 			}
 

--- a/core/src/css/component/decktracker/copy-deckstring.component.scss
+++ b/core/src/css/component/decktracker/copy-deckstring.component.scss
@@ -20,9 +20,10 @@
 	&:hover {
 		--icon-color: var(--color-1);
 	}
+	.message {
+		font-size: 13px;
+		margin-left: 10px;
+	}
 }
 
-.message {
-	font-size: 13px;
-	margin-left: 10px;
-}
+

--- a/core/src/css/component/decktracker/main/decktracker-stats-for-replays.component.scss
+++ b/core/src/css/component/decktracker/main/decktracker-stats-for-replays.component.scss
@@ -15,6 +15,7 @@
 		display: flex;
 		flex-direction: column;
 		width: 155px;
+		height: 75px;
 		align-items: center;
 		justify-content: center;
 		margin-right: 15px;

--- a/core/src/css/component/mercenaries/desktop/mercenaries-personal-hero-stat.component.scss
+++ b/core/src/css/component/mercenaries/desktop/mercenaries-personal-hero-stat.component.scss
@@ -104,6 +104,7 @@
 		width: 60px;
 		margin-right: 20px;
 		flex-shrink: 0;
+		text-align: center;
 
 		::ng-deep progress-bar {
 			.current {

--- a/core/src/js/components/battlegrounds/battles/bgs-simulator-hero-selection.component.ts
+++ b/core/src/js/components/battlegrounds/battles/bgs-simulator-hero-selection.component.ts
@@ -240,6 +240,7 @@ export class BgsSimulatorHeroSelectionComponent
 					.replace(/<i>/g, '')
 					.replace(/<\/i>/g, '')
 					.replace(/<br>/g, '')
+					.replace(/\$/g, '')
 					.replace(/Passive\. /g, '')
 					.replace(/Passive /g, '')
 					.replace(/Passive/g, '')

--- a/core/src/js/components/collection/full-card.component.ts
+++ b/core/src/js/components/collection/full-card.component.ts
@@ -50,7 +50,7 @@ declare let amplitude;
 						<p class="value" [innerHTML]="flavor"></p>
 					</div>
 					<div class="card-info audio" *ngIf="audioClips && audioClips.length > 0">
-						<span class="sub-title" [owTranslate]="'app.collection.card-details.sounds-title'"></span>
+						<div class="sub-title" [owTranslate]="'app.collection.card-details.sounds-title'"></div>
 						<div class="audio-category" *ngFor="let category of audioCategories">
 							<span class="audio-category-title">{{ category.name }}</span>
 							<li class="sound" *ngFor="let sound of category.clips" (mousedown)="playSound(sound)">

--- a/core/src/js/components/collection/full-card.component.ts
+++ b/core/src/js/components/collection/full-card.component.ts
@@ -119,7 +119,7 @@ export class FullCardComponent {
 			card.playerClass !== 'Neutral'
 				? formatClass(card.playerClass, this.i18n)
 				: card.classes?.length
-				? card.classes.map((playerClass) => formatClass(card.playerClass, this.i18n)).join(', ')
+				? card.classes.map((playerClass) => formatClass(playerClass, this.i18n)).join(', ')
 				: formatClass('all', this.i18n);
 		this.type = card.type;
 		this.set = this.cards.setName(card.set);
@@ -257,6 +257,11 @@ export class FullCardComponent {
 			category: 'emote',
 		},
 		{
+			regex: /.*WOW.*/g,
+			value: this.i18n.translateString('app.collection.card-details.sounds.effect.wow'),
+			category: 'emote',
+		},
+		{
 			regex: /.*CONCEDE.*/g,
 			value: this.i18n.translateString('app.collection.card-details.sounds.effect.concede'),
 			category: 'emote',
@@ -267,32 +272,32 @@ export class FullCardComponent {
 			category: 'emote',
 		},
 		{
-			regex: /.*TIMER.*/g,
+			regex: /.*TIMER?.*/g,
 			value: this.i18n.translateString('app.collection.card-details.sounds.effect.timer'),
 			category: 'emote',
 		},
 		{
-			regex: /.*THINK1.*/g,
+			regex: /.*THINK(?:ING_0)?1.*/g,
 			value: this.i18n.translateString('app.collection.card-details.sounds.effect.think-1'),
 			category: 'emote',
 		},
 		{
-			regex: /.*THINK2.*/g,
+			regex: /.*THINK(?:ING_0)?2.*/g,
 			value: this.i18n.translateString('app.collection.card-details.sounds.effect.think-2'),
 			category: 'emote',
 		},
 		{
-			regex: /.*THINK3.*/g,
+			regex: /.*THINK(?:ING_0)?3.*/g,
 			value: this.i18n.translateString('app.collection.card-details.sounds.effect.think-3'),
 			category: 'emote',
 		},
 		{
-			regex: /.*LOW_CARDS.*/g,
+			regex: /.*LOW_?CARDS.*/g,
 			value: this.i18n.translateString('app.collection.card-details.sounds.effect.low-cards'),
 			category: 'emote',
 		},
 		{
-			regex: /.*NO_CARDS.*/g,
+			regex: /.*NO_?CARDS.*/g,
 			value: this.i18n.translateString('app.collection.card-details.sounds.effect.no-cards'),
 			category: 'emote',
 		},
@@ -327,7 +332,7 @@ export class FullCardComponent {
 			category: 'error',
 		},
 		{
-			regex: /.*ERROR_JUST_PLAYED.*/g,
+			regex: /.*ERROR_JUST_PLAYED.*|.*SUMMON_SICKNESS.*/g,
 			value: this.i18n.translateString('app.collection.card-details.sounds.effect.error-just-played'),
 			category: 'error',
 		},
@@ -367,18 +372,23 @@ export class FullCardComponent {
 			category: 'error',
 		},
 		{
-			regex: /.*EVENT_LUNAR_NEW_YEAR.*/g,
-			value: this.i18n.translateString('app.collection.card-details.sounds.effect.lunar-new-year'),
-			category: 'event',
-		},
-		{
 			regex: /.*WINTERVEIL_GREETINGS.*/g,
 			value: this.i18n.translateString('app.collection.card-details.sounds.effect.winterveil-greetings'),
 			category: 'event',
 		},
 		{
-			regex: /.*HAPPY_NEW_YEAR_20.*/g,
-			value: this.i18n.translateString('app.collection.card-details.sounds.effect.happy-new-year-20'),
+			regex: /.*HAPPY_HOLIDAYS.*/g,
+			value: this.i18n.translateString('app.collection.card-details.sounds.effect.happy-holidays'),
+			category: 'event',
+		},
+		{
+			regex: /.*EVENT_LUNAR_NEW_YEAR.*|.*HAPPY_NEW_YEAR_LUNAR.*/g,
+			value: this.i18n.translateString('app.collection.card-details.sounds.effect.lunar-new-year'),
+			category: 'event',
+		},
+		{
+			regex: /.*HAPPY_NEW_YEAR.*/g,
+			value: this.i18n.translateString('app.collection.card-details.sounds.effect.happy-new-year'),
 			category: 'event',
 		},
 		{
@@ -392,7 +402,7 @@ export class FullCardComponent {
 			category: 'event',
 		},
 		{
-			regex: /.*HALLOWS_END.*/g,
+			regex: /.*HALLOWS_END.*|.*HAPPY_HALLOWEEN.*/g,
 			value: this.i18n.translateString('app.collection.card-details.sounds.effect.hallows-end'),
 			category: 'event',
 		},
@@ -400,6 +410,11 @@ export class FullCardComponent {
 			regex: /.*NOBLEGARDEN.*/g,
 			value: this.i18n.translateString('app.collection.card-details.sounds.effect.noblegarden'),
 			category: 'event',
+		},
+		{
+			regex: /.*PICKED.*/g,
+			value: this.i18n.translateString('app.collection.card-details.sounds.effect.picked'),
+			category: 'other',
 		},
 	];
 
@@ -469,7 +484,7 @@ export class FullCardComponent {
 	}
 
 	private transformFlavor(flavor: string): string {
-		const result = flavor.replace(/\n/g, '<br>').replace(/<i>/g, '').replace(/<\/i>/g, '').replace(/<br>/g, ' ');
+		const result = flavor.replace(/\n/g, '<br>').replace(/<i>/g, '').replace(/<\/i>/g, '').replace(/<br>/g, ' ').replace(/[x]/g, '');
 		return result;
 	}
 }

--- a/core/src/js/components/collection/pack-stats.component.ts
+++ b/core/src/js/components/collection/pack-stats.component.ts
@@ -219,9 +219,7 @@ const NON_BUYABLE_BOOSTER_IDS = [
 	BoosterType.STANDARD_SHAMAN,
 	BoosterType.STANDARD_WARRIOR,
 	BoosterType.STANDARD_WARLOCK,
-	BoosterType.STANDARD_BUNDLE,
-	BoosterType.GOLDEN_STANDARD_BUNDLE,
-	BoosterType.WILD_PACK,
+	BoosterType.GOLDEN_STANDARD_BUNDLE
 ];
 
 interface InternalPackGroup {

--- a/core/src/js/components/decktracker/copy-deckstring.component.ts
+++ b/core/src/js/components/decktracker/copy-deckstring.component.ts
@@ -24,8 +24,9 @@ declare let amplitude;
 			<svg class="svg-icon-fill">
 				<use xlink:href="assets/svg/sprite.svg#copy_deckstring" />
 			</svg>
+		
+			<div class="message" *ngIf="!showTooltip || title">{{ copyText || title }}</div>
 		</div>
-		<div class="message" *ngIf="!showTooltip || title">{{ copyText || title }}</div>
 	`,
 	changeDetection: ChangeDetectionStrategy.OnPush,
 })

--- a/core/src/js/components/duels/desktop/duels-hero-stat-vignette.component.ts
+++ b/core/src/js/components/duels/desktop/duels-hero-stat-vignette.component.ts
@@ -17,7 +17,7 @@ import { SimpleBarChartData } from '../../common/chart/simple-bar-chart-data';
 		<div class="duels-hero-stat-vignette" [ngClass]="{ 'unused': playerGamesPlayed === 0 }">
 			<div class="box-side">
 				<div class="name-container">
-					<div class="name" [helpTooltip]="playerClassLoc + ' - ' + name">{{ name }}</div>
+					<div class="name" [helpTooltip]="name + ' (' + playerClassLoc + ')'">{{ name }}</div>
 					<div class="info" [helpTooltip]="numberOfGamesTooltip">
 						<svg>
 							<use xlink:href="assets/svg/sprite.svg#info" />
@@ -76,7 +76,7 @@ export class DuelsHeroStatVignetteComponent {
 		const isNeutralHero =
 			value.cardId.startsWith(CardIds.VanndarStormpikeTavernBrawl) ||
 			value.cardId.startsWith(CardIds.DrektharTavernBrawl);
-		this.name = isNeutralHero ? `${this.playerClassLoc} ${card?.name}` : card?.name;
+		this.name = card?.name;
 		this.secondaryClassIcon = isNeutralHero
 			? `https://static.zerotoheroes.com/hearthstone/asset/firestone/images/deck/classes/${card?.playerClass?.toLowerCase()}.png`
 			: null;

--- a/core/src/js/components/overlays/duels-ooc/duels-deck-widget.component.ts
+++ b/core/src/js/components/overlays/duels-ooc/duels-deck-widget.component.ts
@@ -86,7 +86,7 @@ export class DuelsDeckWidgetComponent {
 			value.type === 'duels'
 				? 'assets/images/deck/ranks/casual_duels.png'
 				: 'assets/images/deck/ranks/heroic_duels.png';
-		this.rankText = `${value.mmr}`;
+		this.rankText = value.mmr == null ? '0' :`${value.mmr}`;
 		this.treasureCardIds = value.treasureCardIds ?? [];
 		this.wins = value.wins;
 		this.losses = value.losses;

--- a/core/src/js/components/settings/decktracker/settings-decktracker-global.ts
+++ b/core/src/js/components/settings/decktracker/settings-decktracker-global.ts
@@ -101,7 +101,7 @@ import { Knob } from '../preference-slider.component';
 			<div class="reset-container">
 				<button
 					(mousedown)="reset()"
-					helpTooltip="'settings.decktracker.global.reset-button-tooltip' | owTranslate"
+					[helpTooltip]="'settings.decktracker.global.reset-button-tooltip' | owTranslate"
 				>
 					<span>{{ resetText }}</span>
 				</button>

--- a/core/src/js/services/collection/sets.ref.ts
+++ b/core/src/js/services/collection/sets.ref.ts
@@ -88,6 +88,7 @@ export const sets: readonly ReferenceSet[] = [
 		id: 'demon_hunter_initiate',
 		name: 'Demon Hunter Initiate',
 		launchDate: new Date('2020-04-02'),
+		isMiniSet: true,
 	},
 	{
 		id: 'yod',
@@ -154,6 +155,7 @@ export const sets: readonly ReferenceSet[] = [
 		id: 'kara',
 		name: 'One Night in Karazhan',
 		launchDate: new Date('2018-08-11'),
+		isMiniSet: true,
 	},
 	{
 		id: 'og',
@@ -164,6 +166,7 @@ export const sets: readonly ReferenceSet[] = [
 		id: 'loe',
 		name: 'League of Explorers',
 		launchDate: new Date('2015-11-12'),
+		isMiniSet: true,
 	},
 	{
 		id: 'tgt',
@@ -174,6 +177,7 @@ export const sets: readonly ReferenceSet[] = [
 		id: 'brm',
 		name: 'Blackrock Mountain',
 		launchDate: new Date('2015-04-02'),
+		isMiniSet: true,
 	},
 	{
 		id: 'gvg',
@@ -184,6 +188,7 @@ export const sets: readonly ReferenceSet[] = [
 		id: 'naxx',
 		name: 'Naxxramas',
 		launchDate: new Date('2014-07-22'),
+		isMiniSet: true,
 	},
 	{
 		id: 'core',

--- a/core/src/js/services/ui-store/duels-ui-helper.ts
+++ b/core/src/js/services/ui-store/duels-ui-helper.ts
@@ -432,7 +432,7 @@ const getTopDeck = (
 		buildNumberAtStart: deckStat.buildNumber,
 	};
 	const deckSummary: DuelsDeckSummary = {
-		deckName: 'tmp',
+		deckName: this.i18n.translateString('app.duels.deck-stat.default-deck-name-blank'),
 		runs: [run],
 		initialDeckList: deckStat.decklist ?? run.initialDeckList,
 		heroCardId: deckStat.heroCardId,


### PR DESCRIPTION
• Increased the size of the "Copy deck code" button. Now not only the icon is clickable, but also the label itself.
• Removed duplicate class names in tooltip for neutral heroes in Duels. Also changed the tooltip, so now it's "Hero (Class)"
• Added a null check for the player's MMR in Duels. (I actually encountered null instead of my MMR)
• Global-stat blocks is set to a fixed height. For the case when in non-English languages the string (stat.label) takes two lines which causes the blocks to have different heights. (The numerical value of the height may need to be changed.)
• Label "Max level!" in Mercs->Progress center aligned (for non-English languages, where it takes two lines)
• Improved BG hero power text sanitizing (for Lich Bazhial)
• Standard and Wild packs have been moved to the main sets. So for now it's true, that special packs is unbuyable ones.
• I hope I fixed reset-button-tooltip