### PR TITLE
Dust recap

### DIFF
--- a/core/src/css/component/notifications/notifications.component.scss
+++ b/core/src/css/component/notifications/notifications.component.scss
@@ -168,10 +168,6 @@ body {
 		.text {
 			display: flex;
 			flex-direction: column;
-
-			.dust-amount:before {
-				content: '+';
-			}
 		}
 	}
 


### PR DESCRIPTION
The plus symbol for dust recap amount should not be added via the css file, but should be contained in the source line. I think this is bad programming practice. This change is also required for non-English languages.