### PR TITLE
Moving packs

### DIFF
--- a/core/src/js/components/collection/pack-stats.component.ts
+++ b/core/src/js/components/collection/pack-stats.component.ts
@@ -219,9 +219,7 @@ const NON_BUYABLE_BOOSTER_IDS = [
 	BoosterType.STANDARD_SHAMAN,
 	BoosterType.STANDARD_WARRIOR,
 	BoosterType.STANDARD_WARLOCK,
-	BoosterType.STANDARD_BUNDLE,
-	BoosterType.GOLDEN_STANDARD_BUNDLE,
-	BoosterType.WILD_PACK,
+	BoosterType.GOLDEN_STANDARD_BUNDLE
 ];
 
 interface InternalPackGroup {


### PR DESCRIPTION
Standard and Wild packs moved to the main sets list. So for now it's true, that special packs is unbuyable ones.