### PR TITLE
Increase Copy deck code button size

### DIFF
--- a/core/src/css/component/decktracker/copy-deckstring.component.scss
+++ b/core/src/css/component/decktracker/copy-deckstring.component.scss
@@ -7,10 +7,10 @@
 }
 
 .copy-deckstring {
+    display: flex;
+    flex-direction: row;
 	--icon-color: var(--color-6);
 	--icon-color-secondary: var(--color-1);
-	max-width: 20px;
-	max-height: 20px;
 
 	svg {
 		height: 16px;

--- a/core/src/css/component/decktracker/copy-deckstring.component.scss
+++ b/core/src/css/component/decktracker/copy-deckstring.component.scss
@@ -20,9 +20,10 @@
 	&:hover {
 		--icon-color: var(--color-1);
 	}
+	.message {
+		font-size: 13px;
+		margin-left: 10px;
+	}
 }
 
-.message {
-	font-size: 13px;
-	margin-left: 10px;
-}
+

--- a/core/src/js/components/decktracker/copy-deckstring.component.ts
+++ b/core/src/js/components/decktracker/copy-deckstring.component.ts
@@ -24,8 +24,9 @@ declare let amplitude;
 			<svg class="svg-icon-fill">
 				<use xlink:href="assets/svg/sprite.svg#copy_deckstring" />
 			</svg>
+		
+			<div class="message" *ngIf="!showTooltip || title">{{ copyText || title }}</div>
 		</div>
-		<div class="message" *ngIf="!showTooltip || title">{{ copyText || title }}</div>
 	`,
 	changeDetection: ChangeDetectionStrategy.OnPush,
 })


### PR DESCRIPTION
Make the "Copy deck code" text itself also clickable. The CSS rule also move to match.