### PR TITLE
Set fixed height for global-stat blocks

### DIFF
--- a/core/src/css/component/decktracker/main/decktracker-stats-for-replays.component.scss
+++ b/core/src/css/component/decktracker/main/decktracker-stats-for-replays.component.scss
@@ -15,6 +15,7 @@
 		display: flex;
 		flex-direction: column;
 		width: 155px;
+		height: 75px;
 		align-items: center;
 		justify-content: center;
 		margin-right: 15px;


### PR DESCRIPTION
Set fixed height for global-stat blocks. For the case when in non-English languages the stat.label takes two lines which causes the blocks to have different heights.

![2022-08-05_16-59-14](https://user-images.githubusercontent.com/43519401/183094011-7e5a8bc5-dbe0-4f6f-9a68-9e3766d546e5.png)

