### PR TITLE
Filter-dropdown-multiselect improvements

### DIFF
--- a/core/src/css/component/filter-dropdown-multiselect.component.scss
+++ b/core/src/css/component/filter-dropdown-multiselect.component.scss
@@ -113,7 +113,7 @@
 			padding: 5px;
 
 			.button {
-				width: 60px;
+				width: 65px;
 				height: 25px;
 				background: var(--color-2);
 				color: var(--color-5);

--- a/core/src/css/component/filter-dropdown-multiselect.component.scss
+++ b/core/src/css/component/filter-dropdown-multiselect.component.scss
@@ -130,7 +130,6 @@
 
 				&:hover:not(.disabled) {
 					background: var(--color-1);
-					color: var(--on-confirmation-text-color);
 				}
 			}
 


### PR DESCRIPTION
• Fix a bug where when you hover over the control buttons in duels hero selection dropdown, labels become not visible because of the same background and font color.

![2022-08-07_15-03-49](https://user-images.githubusercontent.com/43519401/183290309-9637d7c9-5a33-491c-a1ab-bb073b3dc17d.png)

• Enlarge Clear and Reset buttons in multiselect dropdown. In Russian, inscriptions require a little bit more space. Probably in some non-English languages too.

![2022-08-07_14-50-32](https://user-images.githubusercontent.com/43519401/183290338-273d7ca7-1241-435a-aac8-fdb83ae4b55a.png)