### PR TITLE
Settings improvements

### DIFF
--- a/core/src/css/component/settings/general/settings-general.component.scss
+++ b/core/src/css/component/settings/general/settings-general.component.scss
@@ -4,6 +4,7 @@
 
 	settings-general-launch {
 		flex-grow: 1;
+		overflow: auto;
 	}
 
 	settings-general-localization {

--- a/core/src/js/components/settings/decktracker/settings-decktracker-global.ts
+++ b/core/src/js/components/settings/decktracker/settings-decktracker-global.ts
@@ -101,7 +101,7 @@ import { Knob } from '../preference-slider.component';
 			<div class="reset-container">
 				<button
 					(mousedown)="reset()"
-					helpTooltip="'settings.decktracker.global.reset-button-tooltip' | owTranslate"
+					[helpTooltip]="'settings.decktracker.global.reset-button-tooltip' | owTranslate"
 				>
 					<span>{{ resetText }}</span>
 				</button>

--- a/core/src/js/components/settings/general/settings-general-launch.component.ts
+++ b/core/src/js/components/settings/general/settings-general-launch.component.ts
@@ -9,11 +9,12 @@ import { Knob } from '../preference-slider.component';
 	styleUrls: [
 		`../../../../css/global/components-global.scss`,
 		`../../../../css/global/forms.scss`,
+		`../../../../css/global/scrollbar-settings.scss`,
 		`../../../../css/component/settings/settings-common.component.scss`,
 		`../../../../css/component/settings/general/settings-general-launch.component.scss`,
 	],
 	template: `
-		<div class="settings-group general-launch">
+		<div class="settings-group general-launch" scrollable>
 			<section class="toggle-label">
 				<preference-toggle
 					field="launchAppOnGameStart"

--- a/core/src/js/components/settings/general/settings-general-third-party.component.ts
+++ b/core/src/js/components/settings/general/settings-general-third-party.component.ts
@@ -149,7 +149,7 @@ export class SettingsGeneralThirdPartyComponent
 		}),
 		whatNext: this.i18n.translateString('settings.general.third-party.d0nkey.next', {
 			link: `<a href="https://www.d0nkey.top/streamer-instructions" target="_blank">${this.i18n.translateString(
-				'settings.general.third-party.d0nkey.next-link',
+				'settings.general.third-party.d0nkey.instructions-page-link',
 			)}</a>`,
 		}),
 		toggleLabel: this.i18n.translateString('settings.general.third-party.d0nkey.toggle-label'),


### PR DESCRIPTION
• In some non-English languages, some settings labels span two lines and all elements don't fit on the page, so it should be scrollable.

![2022-08-07_19-09-55](https://user-images.githubusercontent.com/43519401/183300610-662c1217-f162-4750-8a04-46c4ed85c9ef.png)

• Fix bug with reset positions button tooltip

![2022-08-07_19-10-52](https://user-images.githubusercontent.com/43519401/183300598-91fef436-ec9b-480e-b68b-dd71ac1fc136.png)

• Fix d0nkey instructions page link
![2022-08-08_00-17-27](https://user-images.githubusercontent.com/43519401/183311312-4e2c9960-70ef-49ec-9849-d78f8a68a96b.png)