### PR TITLE
Fix winrate vs class recap in decktracker

### DIFF
--- a/core/src/js/components/decktracker/overlay/decktracker-winrate-recap.component.ts
+++ b/core/src/js/components/decktracker/overlay/decktracker-winrate-recap.component.ts
@@ -88,7 +88,7 @@ export class DeckTrackerWinrateRecapComponent implements OnDestroy {
 		} else {
 			const readableClass = formatClass(this._stats.opponentClass, this.i18n);
 			this.text = this.i18n.translateString('decktracker.stats.deck-winrate-vs-class', { value: readableClass });
-			this.text = this.i18n.translateString('decktracker.stats.deck-winrate-vs-class-tooltip', {
+			this.tooltip = this.i18n.translateString('decktracker.stats.deck-winrate-vs-class-tooltip', {
 				opponent: readableClass,
 				date: dateFrom,
 			});


### PR DESCRIPTION
There is an obvious mistake here: tooltip string is used instead of recap text
![2022-08-09_14-09-54](https://user-images.githubusercontent.com/43519401/183639145-f4074c4e-abf8-4125-a511-636e87c01d57.png)
