### PR TITLE
Set fixed width for deck import icon in decktracker

### DIFF
--- a/core/src/css/component/decktracker/import-deckstring.component.scss
+++ b/core/src/css/component/decktracker/import-deckstring.component.scss
@@ -13,6 +13,7 @@
 	max-height: 20px;
 
 	.icon {
+		width: 20px;
 		margin-left: 5px;
 	}
 

--- a/core/src/css/component/decktracker/import-deckstring.component.scss
+++ b/core/src/css/component/decktracker/import-deckstring.component.scss
@@ -9,12 +9,11 @@
 .import-deckstring {
 	--icon-color: var(--color-6);
 	--icon-color-secondary: var(--color-1);
-	max-width: 20px;
-	max-height: 20px;
 
 	.icon {
-		width: 20px;
-		margin-left: 5px;
+        width: 10px;
+        height: 14px;
+        margin-left: 5px;
 	}
 
 	&:hover {


### PR DESCRIPTION
In some cases, the import button may shrink to an indistinguishable size, so it should have a fixed width.

![2022-08-09_20-34-42](https://user-images.githubusercontent.com/43519401/183722879-0ed5fabc-4e0a-4c53-b5f3-135ac77b5f8d.png)

