### PR TITLE
Remove duplicate equipment tooltip in mercs team widget

### DIFF
--- a/core/src/js/components/mercenaries/overlay/teams/mercenaries-team-ability.component.ts
+++ b/core/src/js/components/mercenaries/overlay/teams/mercenaries-team-ability.component.ts
@@ -27,7 +27,7 @@ import { CardsFacadeService } from '../../../../services/cards-facade.service';
 					src="https://static.zerotoheroes.com/hearthstone/asset/firestone/mercenaries_ability_frame.png"
 				/>
 			</div>
-			<div class="equipment-item-icon" [cardTooltip]="cardId" *ngIf="type === 'equipment'">
+			<div class="equipment-item-icon" *ngIf="type === 'equipment'">
 				<img class="icon" [src]="buildAbilityArtUrl(cardId)" />
 				<img
 					class="frame"


### PR DESCRIPTION
[Tested locally]
• There is already a tooltip on the element as a whole (line: 16), duplicate tooltip on the equipment icon is not needed.

![2022-08-09_14-59-44](https://user-images.githubusercontent.com/43519401/183698200-a317482a-320d-4dfe-91b2-9e9296cc53f0.png)
