### PR TITLE
Fix determination of multiclass cards

### DIFF
--- a/core/src/js/components/collection/full-card.component.ts
+++ b/core/src/js/components/collection/full-card.component.ts
@@ -117,11 +117,12 @@ export class FullCardComponent {
 		}
 		this.card.owned = this.card.ownedPremium || this.card.ownedNonPremium;
 		this.class =
-			card.playerClass !== 'Neutral'
-				? formatClass(card.playerClass, this.i18n)
-				: card.classes?.length
-				? card.classes.map((playerClass) => formatClass(playerClass, this.i18n)).join(', ')
-				: formatClass('all', this.i18n);
+			card.classes?.length
+			    ? card.classes.map((playerClass) => formatClass(playerClass, this.i18n)).join(', ')
+			    : card.playerClass == 'Neutral'
+			        ? formatClass('all', this.i18n)
+			        : formatClass(card.playerClass, this.i18n);
+				
 		this.type = card.type;
 		this.set = this.cards.setName(card.set);
 		this.rarity = card.rarity;


### PR DESCRIPTION
Most multiclass cards don't have a class specified as Neutral, so we should determine multiclass cards by the length of card.classes (e.g. Raise Dead).