### PR TITLE
Hide empty mercs task list

### DIFF
--- a/core/src/js/components/mercenaries/overlay/teams/mercenaries-team-root..component.ts
+++ b/core/src/js/components/mercenaries/overlay/teams/mercenaries-team-root..component.ts
@@ -56,6 +56,7 @@ import { AbstractSubscriptionComponent } from '../../../abstract-subscription.co
 								<div
 									class="task-list {{ tooltipPosition }}"
 									[ngClass]="{ 'visible': showTaskList$ | async }"
+									*ngIf="_tasks.length!==0"
 									[style.bottom.px]="taskListBottomPx"
 								>
 									<div class="task" *ngFor="let task of _tasks; trackBy: trackByTaskFn">


### PR DESCRIPTION
• If there're no mercenaries tasks, don't display task list. (As an alternative, make a stub "All tasks completed!")

![2022-07-21_02-01-15 2](https://user-images.githubusercontent.com/43519401/183989338-965e7d13-efb0-4b6b-bad4-85a70f329f79.jpg)
