### PR TITLE
Increase replay time field size

### DIFF
--- a/core/src/css/component/replays/replay-info/replay-info.component.scss
+++ b/core/src/css/component/replays/replay-info/replay-info.component.scss
@@ -108,9 +108,10 @@
 
 	&.time {
 		font-size: 13px; 
-		width: 70px;
+		min-width: 70px;
+		max-width: 80px;
 		padding: 0;
-		justify-content: flex-end; 
+		justify-content: flex-end;
 	}
 }
 


### PR DESCRIPTION
In some non-English languages, localized time string doesn't fit in the field.

![2022-08-07_21-00-48](https://user-images.githubusercontent.com/43519401/184070040-6c2be53a-37dc-4643-ace5-fdd8ad72779e.png)
