### PR TITLE
Improved deck recap component layout

### DIFF
--- a/core/src/css/component/decktracker/main/decktracker-deck-recap.component.scss
+++ b/core/src/css/component/decktracker/main/decktracker-deck-recap.component.scss
@@ -17,7 +17,7 @@
 	max-width: 100%;
 
 	.title {
-		color: var(--secondary-text-color);
+		color: var(--color-1);
 		margin-bottom: 30px;
 	}
 
@@ -105,20 +105,20 @@
 	.best-against {
 		margin-left: 40px;
 		border-left: 1px solid var(--default-text-color);
-		padding-left: 40px;
+		width: 100%;
 		display: flex;
 		flex-direction: column;
+		align-items: center;		
 
 		.header {
 			color: var(--default-title-color);
 			font-size: 14px;
-			margin-bottom: 15px;
+			margin-bottom: 10px;
+			text-align: center;
 		}
 
 		.classes {
 			display: flex;
-			position: relative;
-			left: -8px;
 
 			.class-icon {
 				width: 30px;
@@ -155,6 +155,7 @@
 
 			.text {
 				font-size: 13px;
+				text-align: center;
 			}
 		}
 	}


### PR DESCRIPTION
Change title color to be more readable. Layout now better supports two-line strings.

Before:

![2022-08-05_16-57-57](https://user-images.githubusercontent.com/43519401/184158808-a5e6dd28-13c1-426e-9591-9fb0f0697c22.png)

After:
![2022-08-11_17-32-08](https://user-images.githubusercontent.com/43519401/184160313-83e49dcc-a46c-477d-89db-bcf4d9c910c6.png)



![2022-08-11_17-14-07](https://user-images.githubusercontent.com/43519401/184158957-0d607d99-7821-4bae-8585-7af1f6cc81fa.png)

