### PR TITLE
Improved deck summary component layout

### DIFF
--- a/core/src/css/component/decktracker/main/decktracker-deck-summary.component.scss
+++ b/core/src/css/component/decktracker/main/decktracker-deck-summary.component.scss
@@ -9,8 +9,7 @@
 	height: 100%;
 	background: rgba(255, 255, 255, 0.08);
 	position: relative;
-	padding: 10px;
-	padding-bottom: 12px;
+	padding: 10px 5px 12px;
 
 	.deck-name {
 		width: 100%;

--- a/core/src/css/component/mercenaries/desktop/mercenaries-personal-team-summary.component.scss
+++ b/core/src/css/component/mercenaries/desktop/mercenaries-personal-team-summary.component.scss
@@ -9,8 +9,7 @@
 	height: 100%;
 	background: rgba(255, 255, 255, 0.08);
 	position: relative;
-	padding: 10px;
-	padding-bottom: 12px;
+	padding: 10px 5px 12px;
 
 	.team-name {
 		width: 100%;

--- a/core/src/js/components/decktracker/main/decktracker-deck-summary.component.ts
+++ b/core/src/js/components/decktracker/main/decktracker-deck-summary.component.ts
@@ -173,7 +173,8 @@ export class DecktrackerDeckSummaryComponent implements AfterViewInit {
 			month: 'short',
 			day: '2-digit',
 			year: 'numeric',
-		});
+		})
+		.replace(/\s+г\./, ""); //truncate date in russian
 	}
 
 	private buildDecoration(gameFormat: StatGameFormatType) {

--- a/core/src/js/components/mercenaries/desktop/mercenaries-personal-team-summary.component.ts
+++ b/core/src/js/components/mercenaries/desktop/mercenaries-personal-team-summary.component.ts
@@ -169,7 +169,8 @@ export class MercenariesPersonalTeamSummaryComponent {
 			month: 'short',
 			day: '2-digit',
 			year: 'numeric',
-		});
+		})
+		.replace(/\s+г\./, ""); //truncate date in russian
 	}
 
 	private getMostFrequentStarterTeam(gamesForTeam: readonly GameStat[]): readonly string[] {


### PR DESCRIPTION



Before:

![2022-08-11_19-13-44](https://user-images.githubusercontent.com/43519401/184183283-0a67e395-f50d-46d5-9936-85387590832c.png)


After:

![2022-08-11_19-03-20](https://user-images.githubusercontent.com/43519401/184179471-b45a578c-7cc1-4b21-99db-4510e111f69f.png)


I understand that it may not be very correct to use regular expressions to truncate the string, but it can't be done through toLocaleDateString.
