### PR TITLE
Card notification improvements

### DIFF
--- a/core/src/css/component/notifications/notifications.component.scss
+++ b/core/src/css/component/notifications/notifications.component.scss
@@ -102,11 +102,12 @@ body {
 			// padding-left: 30px;
 			padding-right: 14px;
 		}
-
-		.new-card {
-			margin-bottom: 5px;
+		.text-container{
+			display: flex;
+  			flex-direction: column;
+  			justify-content: space-around;
+  			align-items: stretch;
 		}
-
 		.premium-deco {
 			display: none;
 		}

--- a/core/src/js/services/collection/card-notifications.service.ts
+++ b/core/src/js/services/collection/card-notifications.service.ts
@@ -49,9 +49,8 @@ export class CardNotificationsService {
 		const rarity = dbCard?.rarity?.toLowerCase() || 'free';
 
 		const clickText = this.i18n.translateString('app.collection.card-history.click-to-view', {
-			link: `<span class="link">${this.i18n.translateString(
-				'app.collection.card-history.click-to-view-link',
-			)}</span>`,
+			link: `${this.i18n.translateString(
+				'app.collection.card-history.click-to-view-link')}`,
 		});
 		this.notificationService.emitNewNotification({
 			content: `<div class="message-container message-new-card ${goldenClass}">
@@ -71,8 +70,10 @@ export class CardNotificationsService {
 								</svg>
 							</i>
 						</div>
-						<span class="new-card"><span class="new">${newLabel}:</span> ${cardName}!</span>
-						<span class="cta">${clickText}</span>
+						<div class="text-container link">
+							<span class="new-card"><span class="new">${newLabel}:</span> ${cardName}!</span>
+							<span class="cta"> ${clickText}</span>
+						</div>
 					</div>
 					<button class="i-30 close-button">
 						<svg class="svg-icon-fill">


### PR DESCRIPTION
Change layout of receiving cards notification. Now it looks better when card name spans two lines. Also make clickable the entire text area of notification.

**Before:**
![2022-08-02_21-25-58 2](https://user-images.githubusercontent.com/43519401/184936741-658d0450-dc0d-48fe-a05d-b5c4fe76cae2.png)


![2022-08-02_21-28-50 2](https://user-images.githubusercontent.com/43519401/184936880-d92918d6-0211-4aed-a2ea-17344431a5b8.png)

**After:**

![2022-08-16_18-10-59 2](https://user-images.githubusercontent.com/43519401/184936776-0c33ec39-dedf-4e5d-9f15-1d537950284f.png)

