### PR TITLE
Change treasures tier list tooltip position

### DIFF
--- a/core/src/js/components/duels/desktop/secondary/duels-tier.component.ts
+++ b/core/src/js/components/duels/desktop/secondary/duels-tier.component.ts
@@ -10,7 +10,7 @@ import { DuelsTier, DuelsTierItem } from './duels-tier';
 	],
 	template: `
 		<div class="duels-tier">
-			<div class="header {{ label?.toLowerCase() }}" [helpTooltip]="tooltip">
+			<div class="header {{ label?.toLowerCase() }}" [helpTooltip]="tooltip" [helpTooltipPosition]="'top'">
 				{{ label }}
 			</div>
 			<div class="items">


### PR DESCRIPTION
Move tooltip closer to the tier title.

**Before:**

![2022-08-17_03-41-29](https://user-images.githubusercontent.com/43519401/185011586-a1216efa-0721-427b-8566-1b24418380ae.png)

**After:**

![2022-08-17_03-29-51](https://user-images.githubusercontent.com/43519401/185011606-933dc6c8-0b80-48e9-9e19-e189506d171b.png)

