### PR TITLE
Fix achievements progress bar sometimes not displayed

### DIFF
--- a/core/src/css/component/achievements/achievement-progress-bar.component.scss
+++ b/core/src/css/component/achievements/achievement-progress-bar.component.scss
@@ -20,8 +20,10 @@
         display: flex;
         flex-grow: 0;
         flex-shrink: 0;
+        align-items: flex-start;
     
         .progress {
+            height : 100%;
             background: #FFB948;
         }
     }

--- a/core/src/js/components/achievements/achievement-progress-bar.component.ts
+++ b/core/src/js/components/achievements/achievement-progress-bar.component.ts
@@ -12,7 +12,6 @@ import { ChangeDetectionStrategy, Component, Input, ViewEncapsulation } from '@a
 			</div>
 		</div>
 	`,
-	encapsulation: ViewEncapsulation.None,
 	changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class AchievementProgressBarComponent {


### PR DESCRIPTION
The error occurred after some use cases of the application (e.g. going to view any hero in collection and back to achievements). I feel like I'm fixing symptoms of some bigger problem here: progress bar shouldn't be displayed differently depending on the use case.

**Before:**

![2022-08-20_14-12-53](https://user-images.githubusercontent.com/43519401/185743419-4f618d47-7b0c-4946-9698-96b0efcd5eec.png)

**After:**

![2022-08-20_13-51-13](https://user-images.githubusercontent.com/43519401/185742774-7db8556c-daa5-4f49-9b53-bf6751807f62.png)

