### PR TITLE
Improve crop of images for hero portraits

### DIFF
--- a/core/src/css/component/battlegrounds/bgs-hero-portrait.component.scss
+++ b/core/src/css/component/battlegrounds/bgs-hero-portrait.component.scss
@@ -17,18 +17,18 @@
 
 	.icon {
 		position: absolute;
-		top: 0;
+		top: 2%;
 		left: 0;
-		width: 105%;
-		clip-path: polygon(0% 100%, 0% 56%, 15% 20%, 50% 5%, 80% 20%, 90% 56%, 90% 100%);
+		width: 100%;
+		clip-path: polygon(0% 100%, 0% 56%, 15% 20%, 50% 0%, 85% 20%, 100% 56%, 100% 100%);
 	}
 
 	.frame {
 		z-index: 1;
 		position: absolute;
-		top: 0;
-		left: 0;
-		width: 100%;
+		top: -3%;
+		left: -1;
+		width: 103%;
 	}
 
 	.aspect-ratio {

--- a/core/src/css/component/battlegrounds/desktop/categories/battlegrounds-stats-hero-vignette.component.scss
+++ b/core/src/css/component/battlegrounds/desktop/categories/battlegrounds-stats-hero-vignette.component.scss
@@ -32,7 +32,7 @@
 		width: 100px;
 
 		::ng-deep .health {
-			right: -12%;
+			right: -16%;
 			bottom: 5%;
 
 			.icon {

--- a/core/src/css/component/decktracker/main/decktracker-deck-summary.component.scss
+++ b/core/src/css/component/decktracker/main/decktracker-deck-summary.component.scss
@@ -40,13 +40,13 @@
 
 		.skin {
 			width: 100%;
-			clip-path: polygon(0% 100%, 0% 56%, 15% 20%, 50% 5%, 80% 20%, 90% 56%, 90% 100%);
+			clip-path: polygon(0% 100%, 0% 56%, 15% 20%, 50% 0%, 85% 20%, 100% 56%, 100% 100%);
 		}
 		.frame {
 			position: absolute;
-			top: -8%;
-			left: -16%;
-			width: 120%;
+			top: -16%;
+			left: -17%;
+			width: 134%;
 		}
 		.decoration {
 			position: absolute;

--- a/core/src/css/component/duels/desktop/duels-personal-deck-vignette.component.scss
+++ b/core/src/css/component/duels/desktop/duels-personal-deck-vignette.component.scss
@@ -130,18 +130,17 @@
 		position: relative;
 		flex-grow: 0;
 		margin-bottom: 10px;
-		left: 7px;
 		flex-shrink: 0;
 
 		.skin {
 			width: 100%;
-			clip-path: polygon(0% 100%, 0% 56%, 15% 20%, 50% 5%, 75% 20%, 85% 56%, 85% 100%);
+			clip-path: polygon(0% 100%, 0% 56%, 15% 20%, 50% 0%, 85% 20%, 100% 56%, 100% 100%);
 		}
 		.frame {
 			position: absolute;
-			top: -8%;
-			left: -16%;
-			width: 120%;
+			top: -16%;
+			left: -17%;
+			width: 134%;
 		}
 	}
 

--- a/core/src/css/component/duels/desktop/secondary/duels-deck-stats.component.scss
+++ b/core/src/css/component/duels/desktop/secondary/duels-deck-stats.component.scss
@@ -22,18 +22,18 @@
 			width: 80px;
 			position: relative;
 			flex-grow: 0;
-			margin-right: 8px;
+			margin-right: 20px;
 			flex-shrink: 0;
 
 			.skin {
 				width: 100%;
-				clip-path: polygon(0% 100%, 0% 56%, 15% 20%, 50% 5%, 75% 20%, 85% 56%, 85% 100%);
+				clip-path: polygon(0% 100%, 0% 56%, 15% 20%, 50% 0%, 85% 20%, 100% 56%, 100% 100%);
 			}
 			.frame {
 				position: absolute;
-				top: -8%;
-				left: -16%;
-				width: 120%;
+				top: -16%;
+				left: -17%;
+				width: 134%;
 			}
 		}
 


### PR DESCRIPTION
The most noticeable changes are:
• Morgl in Constructed
• Brann and Reno in Duels
• King Lich in Battlegrounds

**Before:**

![2022-08-20_16-26-35 - 2](https://user-images.githubusercontent.com/43519401/185767369-bf700524-9f64-4b97-bb4f-bf264f7e0459.png)

**After:**

![2022-08-20_18-15-25 2](https://user-images.githubusercontent.com/43519401/185767498-4aaebd23-7eed-42ed-bc82-68ae41aba1e7.png)

**Before:**

![2022-08-20_18-26-46](https://user-images.githubusercontent.com/43519401/185767439-96c07256-8bfd-4d25-afb2-211c88c9afb9.png)


**After:**

![2022-08-20_18-50-40](https://user-images.githubusercontent.com/43519401/185767449-fe302dbb-c80e-4069-9dfb-b5e55eefd412.png)


**Before:**

![2022-08-20_20-21-03](https://user-images.githubusercontent.com/43519401/185767385-f4ff3131-c872-4057-8d7a-e279f8c7d5f5.png)

**After:**

![2022-08-20_20-52-15](https://user-images.githubusercontent.com/43519401/185767404-a9c18783-9208-4afe-ba57-3db656b69805.png)




