### PR TITLE
Improve layout of hero-power-info and signature-treasure-info

### DIFF
--- a/core/src/css/component/overlays/duels-ooc/duels-hero-power-info.component.scss
+++ b/core/src/css/component/overlays/duels-ooc/duels-hero-power-info.component.scss
@@ -204,7 +204,7 @@
 	.header {
 		flex-grow: 1;
 		margin-right: 5px;
-		text-align: right;
+		text-align: center;
 	}
 
 	.values {

--- a/core/src/css/component/overlays/duels-ooc/duels-hero-power-info.component.scss
+++ b/core/src/css/component/overlays/duels-ooc/duels-hero-power-info.component.scss
@@ -111,9 +111,6 @@
 		color: var(--default-title-color);
 		font-size: 1.8vh;
 		text-align: center;
-		white-space: nowrap;
-		overflow: hidden;
-		text-overflow: ellipsis;
 		max-width: 100%;
 		margin-bottom: 2vh;
 	}
@@ -123,8 +120,6 @@
 		display: flex;
 		flex-direction: column;
 		flex-shrink: 0;
-		display: flex;
-		flex-direction: column;
 	}
 
 	.win-distribution-section {
@@ -207,11 +202,9 @@
 	flex-wrap: nowrap;
 
 	.header {
-		display: flex;
-		align-items: flex-start;
-		justify-content: flex-start;
-		margin-bottom: 0;
 		flex-grow: 1;
+		margin-right: 5px;
+		text-align: right;
 	}
 
 	.values {

--- a/core/src/css/component/overlays/duels-ooc/duels-signature-treasure-info.component.scss
+++ b/core/src/css/component/overlays/duels-ooc/duels-signature-treasure-info.component.scss
@@ -135,9 +135,6 @@
 		color: var(--default-title-color);
 		font-size: 1.8vh;
 		text-align: center;
-		white-space: nowrap;
-		overflow: hidden;
-		text-overflow: ellipsis;
 		max-width: 100%;
 		margin-bottom: 2vh;
 	}
@@ -147,8 +144,6 @@
 		display: flex;
 		flex-direction: column;
 		flex-shrink: 0;
-		display: flex;
-		flex-direction: column;
 	}
 
 	.win-distribution-section {
@@ -231,11 +226,9 @@
 	flex-wrap: nowrap;
 
 	.header {
-		display: flex;
-		align-items: flex-start;
-		justify-content: flex-start;
-		margin-bottom: 0;
 		flex-grow: 1;
+		margin-right: 5px;
+		text-align: right;
 	}
 
 	.values {

--- a/core/src/css/component/overlays/duels-ooc/duels-signature-treasure-info.component.scss
+++ b/core/src/css/component/overlays/duels-ooc/duels-signature-treasure-info.component.scss
@@ -228,7 +228,7 @@
 	.header {
 		flex-grow: 1;
 		margin-right: 5px;
-		text-align: right;
+		text-align: center;
 	}
 
 	.values {


### PR DESCRIPTION
Add line break for "Win distribution" (for non-English languages). Align Winrate and Popularity labels to the right.  Remove duplicate properties.

**Before:**

![2022-08-21_19-02-21 2](https://user-images.githubusercontent.com/43519401/185812535-ed4ae874-04dc-4038-884f-88151c109630.png)

**After:**

![2022-08-22_01-29-33](https://user-images.githubusercontent.com/43519401/185813730-dbf3e7fb-f242-4569-896d-b464c3777dde.png)


