### PR TITLE
Display filters in cards search results

### DIFF
--- a/core/src/js/components/collection/cards.component.ts
+++ b/core/src/js/components/collection/cards.component.ts
@@ -19,7 +19,7 @@ export const DEFAULT_CARD_HEIGHT = 240;
 	styleUrls: [`../../../css/component/collection/cards.component.scss`, `../../../css/global/scrollbar.scss`],
 	template: `
 		<div class="cards">
-			<div class="show-filter" [ngStyle]="{ 'display': _searchString ? 'none' : 'flex' }">
+			<div class="show-filter">
 				<card-rarity-filter></card-rarity-filter>
 				<card-class-filter></card-class-filter>
 				<card-owned-filter></card-owned-filter>


### PR DESCRIPTION
Since filters affect search results, they should be displayed, otherwise user will be confused.

**Before:**

![2022-08-25_23-59-00](https://user-images.githubusercontent.com/43519401/186770810-b5ecf873-6058-4cee-a87c-01710674a4e7.png)

**After:**

![2022-08-26_00-11-43](https://user-images.githubusercontent.com/43519401/186770795-930f0861-0f09-4edb-b8dd-476bd72bc886.png)

