### PR TITLE
Minor mercs improvements

### DIFF
--- a/core/src/css/component/mercenaries/desktop/mercenaries-personal-hero-stat.component.scss
+++ b/core/src/css/component/mercenaries/desktop/mercenaries-personal-hero-stat.component.scss
@@ -210,7 +210,15 @@
 				left: 0;
 				z-index: 9;
 
-				.icon {
+				.ability-icon {
+					position: absolute;
+					top: 11%;
+					left: 13%;
+					width: 76%;
+					clip-path: ellipse(40% 44% at 50% 50%);
+				}
+
+				.equipment-icon {
 					position: absolute;
 					top: 11%;
 					left: 13%;

--- a/core/src/css/component/mercenaries/desktop/mercenaries-personal-team-summary.component.scss
+++ b/core/src/css/component/mercenaries/desktop/mercenaries-personal-team-summary.component.scss
@@ -67,7 +67,7 @@
 					top: 11%;
 					left: 13%;
 					width: 76%;
-					clip-path: ellipse(40% 44% at 50% 50%);
+					clip-path: ellipse(35% 44% at 50% 50%);
 				}
 
 				.frame {

--- a/core/src/js/components/mercenaries/desktop/mercenaries-personal-hero-stat.component.ts
+++ b/core/src/js/components/mercenaries/desktop/mercenaries-personal-hero-stat.component.ts
@@ -97,7 +97,7 @@ import { PersonalHeroStat } from './mercenaries-personal-hero-stats.component';
 			<div class="abilities">
 				<div class="item" *ngFor="let ability of abilities" [ngClass]="{ 'missing': !ability.owned }">
 					<div class="item-icon" [cardTooltip]="ability.cardId">
-						<img class="icon" [src]="ability.artUrl" />
+						<img class="ability-icon" [src]="ability.artUrl" />
 						<img
 							class="frame"
 							src="https://static.zerotoheroes.com/hearthstone/asset/firestone/mercenaries_ability_frame.png"
@@ -126,7 +126,7 @@ import { PersonalHeroStat } from './mercenaries-personal-hero-stats.component';
 					[ngClass]="{ 'equipped': equipment.equipped, 'missing': !equipment.owned }"
 				>
 					<div class="item-icon" [cardTooltip]="equipment.cardId">
-						<img class="icon" [src]="equipment.artUrl" />
+						<img class="equipment-icon" [src]="equipment.artUrl" />
 						<img
 							class="frame"
 							src="https://static.zerotoheroes.com/hearthstone/asset/firestone/mercenaries_equipment_frame.png"

--- a/core/src/js/components/mercenaries/desktop/mercenaries-personal-hero-stat.component.ts
+++ b/core/src/js/components/mercenaries/desktop/mercenaries-personal-hero-stat.component.ts
@@ -294,8 +294,8 @@ export class MercenariesPersonalHeroStatComponent {
 		const bounties: readonly string[] = value.bountiesWithRewards.map(
 			(bounty) => `
 				<div class="bounty">
-					<div class="bounty-zone">${bounty.bountySetName}</div>
-					<div class="bounty-name">${bounty.bountyName}</div>
+					<div class="bounty-zone" style="white-space: nowrap;">${bounty.bountySetName}</div>
+					<div class="bounty-name" style="white-space: nowrap; overflow: hidden;">${bounty.bountyName}</div>
 				</div>
 			`,
 		);


### PR DESCRIPTION
• **Improve crop of images for mercs portraits in personal team summary**

**Before:**
![2022-08-26_18-53-22](https://user-images.githubusercontent.com/43519401/186988270-132ab836-78e8-4c45-9d2f-aff6453757fa.png)

**After:**
![2022-08-26_19-05-04](https://user-images.githubusercontent.com/43519401/186988301-819ba209-b303-429a-b605-e211d566a443.png)

• **Improve crop of equipment icons in personal hero stats**

Before:
![2022-08-26_17-40-31](https://user-images.githubusercontent.com/43519401/186988324-e440ffc2-1605-43e7-8d75-53f4d696d698.png)

After:
![2022-08-26_17-20-22](https://user-images.githubusercontent.com/43519401/186990221-e6682ca7-5fa6-4243-a23e-987e297179aa.png)


• **Improve layout of where to farm coins tooltip**

Before:
![2022-08-26_23-57-35](https://user-images.githubusercontent.com/43519401/186990986-fe2aa2ea-8a36-4ec4-83f0-d552b97d8bb3.png)

After:
![2022-08-27_00-08-18](https://user-images.githubusercontent.com/43519401/186990996-043f7f2d-fc50-4827-9a9d-7ac77056aff8.png)