### PR TITLE
Minor bgs-opponent-overview improvements

### DIFF
--- a/core/src/css/component/battlegrounds/bgs-player-capsule.component.scss
+++ b/core/src/css/component/battlegrounds/bgs-player-capsule.component.scss
@@ -71,6 +71,7 @@
 			position: absolute;
 			top: 5px;
 			left: 0;
+			z-index: 1;
 		}
 	}
 

--- a/core/src/css/component/battlegrounds/in-game/bgs-opponent-overview-big.component.scss
+++ b/core/src/css/component/battlegrounds/in-game/bgs-opponent-overview-big.component.scss
@@ -106,11 +106,11 @@
 		width: 170px;
 		display: flex;
 		flex-direction: column;
+		justify-content: space-around;
 		padding-left: 15px;
 		padding-right: 15px;
 
 		.title {
-			margin-bottom: 10px;
 			text-align: center;
 		}
 

--- a/core/src/css/component/battlegrounds/in-game/bgs-opponent-overview-big.component.scss
+++ b/core/src/css/component/battlegrounds/in-game/bgs-opponent-overview-big.component.scss
@@ -106,7 +106,7 @@
 		width: 170px;
 		display: flex;
 		flex-direction: column;
-		justify-content: space-around;
+		justify-content: space-evenly;
 		padding-left: 15px;
 		padding-right: 15px;
 

--- a/core/src/js/components/battlegrounds/overlay/bgs-overlay-hero-overview.component.ts
+++ b/core/src/js/components/battlegrounds/overlay/bgs-overlay-hero-overview.component.ts
@@ -29,7 +29,7 @@ import { AbstractSubscriptionComponent } from '../../abstract-subscription.compo
 				[enableSimulation]="false"
 				[maxBoardHeight]="-1"
 				[currentTurn]="currentTurn"
-				tavernTitle="Latest upgrade"
+				[tavernTitle]="'battlegrounds.in-game.opponents.tavern-latest-upgrade-title' | owTranslate"
 				[showTavernsIfEmpty]="false"
 				[showLastOpponentIcon]="isLastOpponent"
 			></bgs-opponent-overview-big>


### PR DESCRIPTION
• **Externalized string "Latest upgrade"**

**Before:**
![2022-08-27_23-26-25](https://user-images.githubusercontent.com/43519401/187047415-1d969d40-3b10-4fe5-8f1a-78a7e12cd36a.png)

**After:**

![2022-08-27_19-23-40 2](https://user-images.githubusercontent.com/43519401/187042565-2fbe711a-badf-4c07-9f95-4dc7a04df3fd.png)

• **Improved layout of tavern upgrades section of bgs-opponent-overview**

• **Fixed last opponent icon overlap with hero frame**

**After:**

![2022-08-27_20-32-14 2](https://user-images.githubusercontent.com/43519401/187042566-4521c4a3-a802-43f4-a50c-d40a85e0bcef.png)



