### PR TITLE
Fix 0 speed abilities in mercs personal hero stats

### DIFF
--- a/core/src/js/components/mercenaries/desktop/mercenaries-personal-hero-stat.component.ts
+++ b/core/src/js/components/mercenaries/desktop/mercenaries-personal-hero-stat.component.ts
@@ -196,7 +196,7 @@ export class MercenariesPersonalHeroStatComponent {
 				return {
 					cardId: info.cardId,
 					owned: info.owned,
-					speed: info.speed,
+					speed: info.speed ?? 0,
 					cooldown: info.cooldown,
 					tier: info.tier,
 					artUrl: `https://static.zerotoheroes.com/hearthstone/cardart/256x/${info.cardId}.jpg`,


### PR DESCRIPTION
**Before:**

![2022-08-31_02-21-29](https://user-images.githubusercontent.com/43519401/187560409-c7730c38-fac7-4749-8100-483e4c4b3a69.png)

![2022-08-31_02-20-28](https://user-images.githubusercontent.com/43519401/187560412-bf5326ec-d05d-4daf-bb45-b93197d1b120.png)


**After:**

![2022-08-31_02-12-21](https://user-images.githubusercontent.com/43519401/187560557-c904eba7-0bfc-4a95-9601-bf57be1a1cd5.png)


![2022-08-31_02-13-16](https://user-images.githubusercontent.com/43519401/187559759-7711ce11-27eb-402c-8911-2b3ec6ff5789.png)
