### PR TITLE
Improve layout of bgs-next-opponent-overview

### DIFF
--- a/core/src/css/component/battlegrounds/bgs-board.component.scss
+++ b/core/src/css/component/battlegrounds/bgs-board.component.scss
@@ -13,7 +13,6 @@
 	padding: 0;
 	margin: 0;
 	width: 100%;
-	height: 100%;
 	position: relative;
 	flex-grow: 1;
 	flex-shrink: 1;
@@ -54,10 +53,12 @@ li {
 	font-size: var(--variable-title-font-size);
 
 	&.empty {
-		margin-top: auto;
-		margin-bottom: auto;
-		// padding-right: 10px;
-		// padding-left: 10px;
+		display: flex;
+		align-items: center;
+		height: calc(100% - 30px);
+		&.not-met {
+			height: 100%;
+		}
 	}
 }
 

--- a/core/src/css/component/battlegrounds/in-game/bgs-next-opponent-overview.component.scss
+++ b/core/src/css/component/battlegrounds/in-game/bgs-next-opponent-overview.component.scss
@@ -48,7 +48,6 @@
 
 bgs-opponent-overview-big {
 	max-height: 260px;
-	height: 260px;
 	flex-shrink: 0;
 	margin-left: 20px;
 }
@@ -74,7 +73,7 @@ bgs-hero-face-off {
 	// min-height: 0;
 	// overflow: auto;
 	// So that the divine shields are the top are not truncated
-	padding-top: 20px;
+	padding-top: 10px;
 	position: relative;
 	top: 0px;
 }

--- a/core/src/css/component/battlegrounds/in-game/bgs-opponent-overview-big.component.scss
+++ b/core/src/css/component/battlegrounds/in-game/bgs-opponent-overview-big.component.scss
@@ -17,12 +17,14 @@
 		flex-shrink: 0;
 		width: 80%;
 		border-right: 1px solid var(--color-3);
-		justify-content: space-evenly;
+		justify-content: space-between;
 		position: relative;
 
 		::ng-deep bgs-board {
 			flex-shrink: 0;
-			height: calc(100% - 80px);
+			height: calc(100% - 130px);
+			min-height: 100px;
+			justify-content: flex-start;
 
 			.board {
 				margin-bottom: 0px;
@@ -121,9 +123,11 @@
 
 	.tavern-upgrades {
 		width: 170px;
+		height: 100%;
 		display: flex;
 		flex-direction: column;
 		justify-content: space-evenly;
+		align-items: center;
 		padding-left: 15px;
 		padding-right: 15px;
 
@@ -138,6 +142,7 @@
 			// justify-content: flex-start;
 			display: grid;
 			grid-template-columns: 50% 50%;
+			column-gap: 5px;
 		}
 
 		.tavern-upgrade {
@@ -150,6 +155,7 @@
 		.label {
 			margin-top: -10px;
 			text-align: center;
+			white-space: nowrap;
 		}
 
 		::ng-deep tavern-level-icon .tavern-level-icon {

--- a/core/src/css/component/battlegrounds/in-game/bgs-opponent-overview.component.scss
+++ b/core/src/css/component/battlegrounds/in-game/bgs-opponent-overview.component.scss
@@ -1,5 +1,6 @@
 .opponent-overview {
 	display: flex;
+	justify-content: flex-end;
 	flex-grow: 1;
 	flex-shrink: 1;
 	background: rgba(255, 255, 255, 0.08);
@@ -91,12 +92,6 @@
 				}
 			}
 		}
-
-		.filler {
-			display: flex;
-			flex-grow: 1;
-			height: 100%;
-		}
 	}
 
 	bgs-triples {
@@ -115,9 +110,6 @@
 			.title {
 				width: auto;
 				margin: 0;
-			}
-			.subtitle {
-				margin: auto;
 			}
 			.triple-tiers {
 				justify-content: space-around;
@@ -144,21 +136,27 @@
 		width: auto;
 		flex-grow: 1;
 		flex-direction: column;
+		justify-content: space-evenly;
 		border-right: 1px solid var(--color-3);
 		padding-right: 10px;
 		align-items: flex-start;
-		max-width: 465px;
+		max-width: 500px;
+		overflow: hidden;
 
 		.title {
 			margin-left: 20px;
-			margin-bottom: 10px;
 			text-align: center;
+			white-space: nowrap;
+			overflow: hidden;
+			text-overflow: ellipsis;
+		}
+		.subtitle {
+			margin-left: 20px;
 		}
 
 		.upgrades {
 			display: flex;
-			flex-wrap: wrap;
-			overflow: hidden;
+			flex-wrap: nowrap;
 			justify-content: flex-start;
 
 			.upgrades {
@@ -215,9 +213,6 @@
 		}
 		.tavern-upgrades {
 			display: flex;
-		}
-		.filler {
-			display: none;
 		}
 	}
 }

--- a/core/src/css/component/battlegrounds/in-game/bgs-quest-rewards.component.scss
+++ b/core/src/css/component/battlegrounds/in-game/bgs-quest-rewards.component.scss
@@ -5,14 +5,16 @@
 .rewards-container {
 	display: flex;
 	flex-direction: column;
+	align-items: center;
+	justify-content: space-evenly;
 	border-right: 1px solid var(--color-3);
-	padding-right: 10px;
-	align-items: flex-start;
 	width: 100%;
+	height: 100%;
+	padding-left: 10px;
+	padding-right: 10px;
 
 	.title {
-		margin-left: 20px;
-		margin-bottom: 10px;
+		width: 100%;
 		text-align: center;
 		white-space: nowrap;
 		overflow: hidden;
@@ -20,18 +22,18 @@
 	}
 
 	.subtitle {
-		margin-top: auto;
-		margin-bottom: auto;
+		width: 100%;
+		text-align: center;
 		align-self: center;
 		justify-self: center;
 	}
 
 	.rewards {
+		width: 100%;
 		display: flex;
+		justify-content: center;
 		flex-wrap: wrap;
 		overflow: hidden;
-		justify-content: flex-start;
-		margin-left: 10px;
 		position: relative;
 
 		.reward {

--- a/core/src/css/component/battlegrounds/in-game/bgs-triples.component.scss
+++ b/core/src/css/component/battlegrounds/in-game/bgs-triples.component.scss
@@ -6,11 +6,15 @@
 .triples-section {
 	display: flex;
 	align-items: center;
+	justify-content: center;
 	flex-grow: 1;
 
 	.title {
 		width: 90px;
 		margin-right: 30px;
+	}
+	.subtitle {
+		text-align: center;
 	}
 
 	.triple-tiers {

--- a/core/src/css/component/battlegrounds/overlay/bgs-overlay-hero-overview.component.scss
+++ b/core/src/css/component/battlegrounds/overlay/bgs-overlay-hero-overview.component.scss
@@ -117,15 +117,13 @@
 				}
 
 				.triples-section {
-					flex-direction: column;
-					align-items: flex-start;
-					justify-content: space-between;
-					padding-bottom: 4px;
-					margin-right: 15px;
+					//flex-direction: column;
+					//align-items: flex-start;
+					//justify-content: space-between;
 
 					.title {
 						width: 70px;
-						margin-right: 0;
+						//margin-right: 0;
 					}
 
 					.triple {
@@ -156,7 +154,7 @@
 					justify-content: space-between;
 					width: auto;
 					border-right: 1px solid var(--color-3);
-					padding-right: 10px;
+					
 
 					.rewards-container .title {
 						display: flex;

--- a/core/src/js/components/battlegrounds/bgs-board.component.ts
+++ b/core/src/js/components/battlegrounds/bgs-board.component.ts
@@ -23,15 +23,17 @@ import { normalizeCardId } from './post-match/card-utils';
 		</div>
 		<div class="board-turn" *ngIf="!customTitle && _entities && finalBoard">Your final board</div>
 		<div
-			class="board-turn empty"
+			class="board-turn empty not-met"
 			*ngIf="!customTitle && !finalBoard && (!_entities || !boardTurn || !isNumber(currentTurn - boardTurn))"
-			[owTranslate]="'battlegrounds.board.opponent-not-met'"
-		></div>
+		> 
+			<span [owTranslate]="'battlegrounds.board.opponent-not-met'"></span>
+		</div>
 		<div
 			class="board-turn empty"
 			*ngIf="!customTitle && _entities && _entities.length === 0 && isNumber(currentTurn - boardTurn)"
-			[owTranslate]="'battlegrounds.board.last-board-empty'"
-		></div>
+		>
+			<span [owTranslate]="'battlegrounds.board.last-board-empty'"></span>
+		</div>
 		<ul class="board" *ngIf="_entities && _entities.length > 0">
 			<div class="minion-container" *ngFor="let entity of _entities; trackBy: trackByEntity">
 				<li>

--- a/core/src/js/components/battlegrounds/in-game/bgs-opponent-overview-big.component.ts
+++ b/core/src/js/components/battlegrounds/in-game/bgs-opponent-overview-big.component.ts
@@ -40,8 +40,8 @@ import { LocalizationFacadeService } from '../../../services/localization-facade
 				</div>
 			</div>
 			<div class="tavern-upgrades" *ngIf="showTavernsIfEmpty || tavernUpgrades?.length">
-				<div class="title">{{ tavernTitle }}</div>
-				<div class="upgrades">
+				<div class="title" *ngIf="tavernUpgrades?.length">{{ tavernTitle }}</div>
+				<div class="upgrades" *ngIf="tavernUpgrades?.length">
 					<div class="tavern-upgrade" *ngFor="let upgrade of tavernUpgrades || []; trackBy: trackByUpgradeFn">
 						<tavern-level-icon [level]="upgrade.tavernTier" class="tavern"></tavern-level-icon>
 						<div
@@ -51,7 +51,12 @@ import { LocalizationFacadeService } from '../../../services/localization-facade
 						></div>
 					</div>
 				</div>
+				<div class="tavern-upgrades empty"
+					*ngIf="!tavernUpgrades?.length"
+					[owTranslate]="'battlegrounds.in-game.opponents.tavern-empty-state'"
+				></div>
 			</div>
+			
 		</bgs-player-capsule>
 	`,
 	changeDetection: ChangeDetectionStrategy.OnPush,

--- a/core/src/js/components/battlegrounds/in-game/bgs-opponent-overview.component.ts
+++ b/core/src/js/components/battlegrounds/in-game/bgs-opponent-overview.component.ts
@@ -33,10 +33,9 @@ import { BgsTriple } from '../../../models/battlegrounds/in-game/bgs-triple';
 					[boardTurn]="boardTurn"
 					[tooltipPosition]="'top'"
 				></bgs-board>
-				<div class="filler"></div>
 			</div>
 			<div class="tavern-upgrades">
-				<div class="title" [owTranslate]="'battlegrounds.in-game.opponents.tavern-last-upgrade-title'"></div>
+				<div class="title" *ngIf="tavernUpgrades?.length" [owTranslate]="'battlegrounds.in-game.opponents.tavern-last-upgrade-title'"></div>
 				<div class="upgrades" *ngIf="tavernUpgrades?.length">
 					<div class="tavern-upgrade" *ngFor="let upgrade of tavernUpgrades || []; trackBy: trackByUpgradeFn">
 						<tavern-level-icon [level]="upgrade.tavernTier" class="tavern"></tavern-level-icon>


### PR DESCRIPTION
**What was done:**
* All empty states are center aligned
* Changed empty state for tavern upgrades: removed Last upgrades/Tavern upgrades label
* Quest rewards centered
* Improved view display when zoom level is increased.


**Before:**

![2022-09-06_01-46-00](https://user-images.githubusercontent.com/43519401/188530349-6dfc9ab2-01ff-4647-a370-e0c426e4aaba.png)

**After:**

![2022-09-02_18-02-33](https://user-images.githubusercontent.com/43519401/188530506-e1b40521-3960-4686-b9f2-4b5258816271.png)


**Before:**

![2022-09-06_01-48-28](https://user-images.githubusercontent.com/43519401/188519736-52c4cdae-645c-4fed-8141-369b4c7e257d.png)

**After:**

![2022-09-02_18-02-33](https://user-images.githubusercontent.com/43519401/188520195-8efeb59f-35b9-4fa8-8c6d-456c8406546e.png)

**Before:**

![2022-09-06_02-02-05](https://user-images.githubusercontent.com/43519401/188529598-4353b9b9-23ef-43ab-b035-a3e140c85eb0.png)

**After:**

![2022-09-06_04-38-58](https://user-images.githubusercontent.com/43519401/188529123-e1e66b38-210a-46c7-b6c3-e168b8e0e5f1.png)



