### PR TITLE
Improve layout of bgs-hero-overview

### DIFF
--- a/core/src/css/component/battlegrounds/bgs-hero-portrait.component.scss
+++ b/core/src/css/component/battlegrounds/bgs-hero-portrait.component.scss
@@ -17,8 +17,8 @@
 
 	.icon {
 		position: absolute;
-		top: 2%;
-		left: 0;
+		top: 6%;
+		left: 1%;
 		width: 100%;
 		clip-path: polygon(0% 100%, 0% 56%, 15% 20%, 30% 7%, 50% 0%, 70% 7%, 85% 20%, 100% 56%, 100% 100%);
 	}
@@ -26,8 +26,7 @@
 	.frame {
 		z-index: 1;
 		position: absolute;
-		top: -3%;
-		left: -1;
+		left: 1%;
 		width: 103%;
 	}
 
@@ -122,7 +121,8 @@
 	}
 
 	&.new {
-		bottom: 6%;
+		bottom: 4%;
+		left: 70%;
 	}
 }
 

--- a/core/src/css/component/battlegrounds/hero-selection/bgs-hero-overview.component.scss
+++ b/core/src/css/component/battlegrounds/hero-selection/bgs-hero-overview.component.scss
@@ -1,23 +1,20 @@
 .hero-overview {
 	display: flex;
 	flex-direction: column;
+	justify-content: space-evenly;
 	background: rgba(255, 255, 255, 0.08);
 	height: 100%;
 	align-items: center;
-	padding: 10px;
-	padding-left: 10%;
-	padding-right: 10%;
+	padding: 10%;
 	position: relative;
 
 	.name {
 		color: var(--default-title-color);
-		font-size: var(--variable-title-font-size);
+		font-size: var(--variable-title-font-size-big);
 		text-overflow: ellipsis;
 		white-space: nowrap;
 		width: 100%;
 		text-align: center;
-		padding-left: 10px;
-		padding-right: 10px;
 	}
 
 	.tier {
@@ -62,61 +59,55 @@
 	}
 
 	.portrait-container {
-		width: 12vh;
-		margin-top: 10px;
-		margin-bottom: 10px;
+		width: 100%;
 		position: relative;
 		display: flex;
-		justify-content: center;
+		justify-content: space-evenly;
 		align-items: center;
 		flex-direction: column;
 
 		::ng-deep bgs-hero-portrait {
-			.hero-portrait-frame {
-				width: 85px;
-			}
+			width: 70%;
 			.health {
 				.icon {
 					display: none;
 				}
 				.value {
-					font-size: 16px;
+					font-size: 2vw;
 					margin-top: 0;
 					position: relative;
-					top: -4px;
+					top: 25%;
 				}
 			}
 		}
+	}
+	.achievements {
+		width: 100%;
+		height: 50px;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		
+		position: relative;
 
-		.achievements {
-			width: calc(100% + 40px);
-			height: 50px;
-			display: flex;
-			align-items: center;
-			justify-content: center;
-			margin-top: -10px;
-			margin-bottom: -10px;
-			position: relative;
+		.achievement {
+			width: 4vw;
+			//height: 50px;
+			margin-left: -8px;
+			margin-right: -8px;
 
-			.achievement {
-				width: 50px;
-				height: 50px;
-				margin-left: -8px;
-				margin-right: -8px;
+			.icon {
+				width: 100%;
+				height: 100%;
 
-				.icon {
-					width: 100%;
-					height: 100%;
-
-					::ng-deep svg {
-						margin-top: 0 !important;
-					}
+				::ng-deep svg {
+					margin-top: 0 !important;
 				}
+			}
 
-				&:not(.completed) {
-					.icon {
-						opacity: 0.4;
-					}
+			&:not(.completed) {
+				.icon {
+					opacity: 0.4;
 				}
 			}
 		}
@@ -130,7 +121,7 @@
 		i {
 			--icon-color: var(--color-5);
 			width: 50%;
-			height: 5000px; // Just a big value so that we can use the width as a constraint
+			height: 100%;
 		}
 	}
 }

--- a/core/src/css/component/battlegrounds/hero-selection/bgs-hero-stats.component.scss
+++ b/core/src/css/component/battlegrounds/hero-selection/bgs-hero-stats.component.scss
@@ -7,6 +7,7 @@
 	margin-top: 0.1vh;
 	display: flex;
 	flex-direction: column;
+	justify-content: space-evenly;
 
 	.stat-details {
 		display: flex;

--- a/core/src/js/components/battlegrounds/hero-selection/bgs-hero-overview.component.ts
+++ b/core/src/js/components/battlegrounds/hero-selection/bgs-hero-overview.component.ts
@@ -37,18 +37,18 @@ import { BgsHeroSelectionTooltipComponent } from './bgs-hero-selection-tooltip.c
 					[cardTooltip]="_hero.heroPowerCardId"
 					[cardTooltipClass]="'bgs-hero-select'"
 				></bgs-hero-portrait>
-				<div class="achievements">
+			</div>
+			<div class="achievements">
+				<div
+					class="achievement"
+					*ngFor="let achievement of achievementsToDisplay; let i = index; trackBy: trackByFn"
+					[ngClass]="{ 'completed': achievement.completed }"
+				>
 					<div
-						class="achievement"
-						*ngFor="let achievement of achievementsToDisplay; let i = index; trackBy: trackByFn"
-						[ngClass]="{ 'completed': achievement.completed }"
-					>
-						<div
-							class="icon"
-							inlineSVG="assets/svg/achievements/categories/hearthstone_game.svg"
-							[helpTooltip]="achievement.text"
-						></div>
-					</div>
+						class="icon"
+						inlineSVG="assets/svg/achievements/categories/hearthstone_game.svg"
+						[helpTooltip]="achievement.text"
+					></div>
 				</div>
 			</div>
 			<bgs-hero-stats [hero]="_hero"></bgs-hero-stats>


### PR DESCRIPTION
**What was done:**
* Align components evenly
* Enlarge hero portrait
* Increase achievements size

**Before:**

![2022-09-06_16-04-27](https://user-images.githubusercontent.com/43519401/188643221-3ed811ec-90c7-4490-ac77-eb9a14b58cd2.png)


**After:**

![2022-09-06_15-16-22](https://user-images.githubusercontent.com/43519401/188636273-4a65f44f-2fb1-47fe-a1ea-c67f9a62e3a9.png)
