### PR TITLE
Minor visual improvements

### DIFF
--- a/core/src/css/component/battlegrounds/graph-with-comparison.component.scss
+++ b/core/src/css/component/battlegrounds/graph-with-comparison.component.scss
@@ -101,7 +101,7 @@
 						max-width: 150px;
 					}
 
-					.average {
+					.player + .average {
 						border-left: 1px solid rgba(#841063, 0.2);
 						padding-left: 7px;
 						margin-left: 7px;

--- a/core/src/css/component/collection/pack-stats.component.scss
+++ b/core/src/css/component/collection/pack-stats.component.scss
@@ -23,6 +23,7 @@
 
 		&.best-packs-header {
 			margin-top: 15px;
+			width: fit-content;
 		}
 
 		.show-buyable-packs {

--- a/core/src/css/component/common/chart/pie-chart.component.scss
+++ b/core/src/css/component/common/chart/pie-chart.component.scss
@@ -41,6 +41,7 @@
 			border-radius: 50%;
 			width: 20px;
 			height: 20px;
+			flex-shrink: 0;
 			margin-right: 10px;
 		}
 	}

--- a/core/src/css/component/duels/desktop/filters/_duels-filters.component.scss
+++ b/core/src/css/component/duels/desktop/filters/_duels-filters.component.scss
@@ -31,7 +31,6 @@
 .hide-below-threshold-link,
 .show-hidden-decks-link {
 	align-self: flex-end;
-	flex-grow: 1;
 	height: 30px;
 	display: flex;
 	align-items: flex-end;


### PR DESCRIPTION
**Before:**
![2022-09-10_02-50-18](https://user-images.githubusercontent.com/43519401/189479872-a3be59a9-2f01-4e42-b77b-00455d02a4e6.png)

**After:**
![2022-09-10_02-50-43](https://user-images.githubusercontent.com/43519401/189479870-c77c576e-3b3d-4a4c-9f3e-dadf9c12a0d7.png)

**Before:**
![2022-09-10_02-48-54](https://user-images.githubusercontent.com/43519401/189479881-c4563c63-c13e-4c00-aff7-9d029f038796.png)

**After:**
![2022-09-10_02-49-15](https://user-images.githubusercontent.com/43519401/189479876-f1a304b7-1f1f-4028-ac30-e9f191838868.png)

**Before:**
![2022-09-10_00-01-22](https://user-images.githubusercontent.com/43519401/189479887-3c2cd894-ac72-45e9-a2b5-68b7345a9fa1.png)
**After:**
![2022-09-10_00-01-32](https://user-images.githubusercontent.com/43519401/189479893-d6c1b2b2-3cdd-4a26-b298-b539feab9dc5.png)

**Display border between two sections in graph with comparison tooltip only if both exist.**

**Before:**
![2022-09-10_15-38-16](https://user-images.githubusercontent.com/43519401/189483737-7ae049f0-eca6-4245-a52b-378d7f44b0b1.png)

**After:**

![2022-09-10_15-27-04](https://user-images.githubusercontent.com/43519401/189483734-a438bf0d-e315-4b3c-ad87-b801411c089f.png)

