### PR TITLE
Decktracker improvements

### DIFF
--- a/core/src/css/component/decktracker/overlay/decktracker-title-bar.component.scss
+++ b/core/src/css/component/decktracker/overlay/decktracker-title-bar.component.scss
@@ -21,7 +21,7 @@ decktracker-cards-recap {
 decktracker-winrate-recap {
 	flex-shrink: 1;
 	flex-grow: 1;
-	max-width: 100%;
+	width: 100%;
 
 	::ng-deep .text {
 		width: calc(100% - 120px);

--- a/core/src/js/components/decktracker/overlay/decktracker-cards-recap.component.ts
+++ b/core/src/js/components/decktracker/overlay/decktracker-cards-recap.component.ts
@@ -9,24 +9,22 @@ import { DeckState } from '../../../models/decktracker/deck-state';
 	],
 	template: `
 		<div class="cards-recap">
-			<div class="recap cards-in-hand">
-				<div
-					class="icon"
-					[helpTooltip]="'decktracker.cards-in-hand-tooltip' | owTranslate"
-					[bindTooltipToGameWindow]="true"
-				>
+			<div class="recap cards-in-hand"
+				[helpTooltip]="'decktracker.cards-in-hand-tooltip' | owTranslate"
+				[bindTooltipToGameWindow]="true"
+			>
+				<div class="icon">
 					<svg class="svg-icon-fill">
 						<use xlink:href="assets/svg/sprite.svg#cards_in_hand" />
 					</svg>
 				</div>
 				<div class="count">{{ cardsInHand }}</div>
 			</div>
-			<div class="recap cards-in-deck">
-				<div
-					class="icon"
-					[helpTooltip]="'decktracker.cards-left-in-deck-tooltip' | owTranslate"
-					[bindTooltipToGameWindow]="true"
-				>
+			<div class="recap cards-in-deck"
+				[helpTooltip]="'decktracker.cards-left-in-deck-tooltip' | owTranslate"
+				[bindTooltipToGameWindow]="true"
+			>
+				<div class="icon">
 					<svg class="svg-icon-fill">
 						<use xlink:href="assets/svg/sprite.svg#cards_in_deck" />
 					</svg>


### PR DESCRIPTION
* Now cards in deck and cards in hand tooltips are displayed on entire block, not just on icon.
* Visual improvements

**Before:**

![2022-09-11_20-53-52](https://user-images.githubusercontent.com/43519401/189552285-8821f51a-a8ad-4688-89f3-867068b37a4d.png)

**After:**

![2022-09-12_00-47-29](https://user-images.githubusercontent.com/43519401/189552279-59335737-ef48-4da0-b569-6463745b1b3d.png)

