### PR TITLE
Hide speed value for abilities with Discover and Battlecry effects

### DIFF
--- a/core/src/js/services/mercenaries/mercenaries-utils.ts
+++ b/core/src/js/services/mercenaries/mercenaries-utils.ts
@@ -209,8 +209,8 @@ export const isPassiveMercsTreasure = (cardId: string, allCards: CardsFacadeServ
 	const refCard = allCards.getCard(cardId);
 	return (
 		refCard?.mercenaryPassiveAbility ||
-		// For Start of game effects
 		refCard.mechanics?.includes(GameTag[GameTag.HIDE_STATS]) ||
+		refCard.mechanics?.includes(GameTag[GameTag.HIDE_COST]) ||
 		refCard.mechanics?.includes(GameTag[GameTag.START_OF_GAME])
 	);
 };


### PR DESCRIPTION
**Before:**

![2022-10-08_02-40-02](https://user-images.githubusercontent.com/43519401/194676015-692284bb-1f58-42d4-ae2d-ba0b6253e22c.png)


**After:**

![2022-10-08_02-44-57](https://user-images.githubusercontent.com/43519401/194676019-e268e6f7-05b6-4aea-85ee-6d492d34edc7.png)
