### PR TITLE
Add display of neutral icon in mercs team widget

### DIFF
--- a/core/src/js/components/mercenaries/overlay/teams/mercenaries-team-mercenary.component.ts
+++ b/core/src/js/components/mercenaries/overlay/teams/mercenaries-team-mercenary.component.ts
@@ -58,7 +58,7 @@ export class MercenariesTeamMercenaryComponent {
 		this.mercCardId = value.cardId;
 		this.cardImage = `url(https://static.zerotoheroes.com/hearthstone/cardart/tiles/${value.cardId}.jpg)`;
 		this.roleIcon =
-			!value.role || value.role === TagRole[TagRole.NEUTRAL] || value.role === TagRole[TagRole.INVALID]
+			!value.role || value.role === TagRole[TagRole.INVALID]
 				? null
 				: `https://static.zerotoheroes.com/hearthstone/asset/firestone/mercenaries_icon_golden_${value.role?.toLowerCase()}.png`;
 		this.name = value.cardId


### PR DESCRIPTION
Along with this commit, you should upload this image to the server at https://static.zerotoheroes.com/hearthstone/asset/firestone/mercenaries_icon_golden_neutral.png

![mercenaries_icon_golden_neutral](https://user-images.githubusercontent.com/43519401/195396121-437e956d-542e-496f-a023-9ec1956b4674.png)
