### PR TITLE
Hide speed value for abilities with Discover and Battlecry effects

### DIFF
--- a/core/src/js/services/mercenaries/mercenaries-utils.ts
+++ b/core/src/js/services/mercenaries/mercenaries-utils.ts
@@ -215,7 +215,9 @@ export const isPassiveMercsTreasure = (cardId: string, allCards: CardsFacadeServ
 		refCard?.mercenaryPassiveAbility ||
 		refCard.mechanics?.includes(GameTag[GameTag.HIDE_STATS]) ||
 		refCard.mechanics?.includes(GameTag[GameTag.HIDE_COST]) ||
-		refCard.mechanics?.includes(GameTag[GameTag.START_OF_GAME])
+		refCard.mechanics?.includes(GameTag[GameTag.START_OF_GAME]) ||
+		refCard.mechanics?.includes(GameTag[GameTag.DISCOVER]) ||
+		refCard.mechanics?.includes(GameTag[GameTag.BATTLECRY])
 	);
 };
 


### PR DESCRIPTION
Apparently, not all abilities with Discover and Battlecry effects have the HIDE_COST tag.

**Before:**

![2022-10-12_22-19-24](https://user-images.githubusercontent.com/43519401/195462218-eba41f61-9a34-464f-a642-4b36f4db9ea8.png)

**After:**

![2022-10-12_22-29-50](https://user-images.githubusercontent.com/43519401/195462224-aba39528-45e5-4b26-9465-7ba357c40c2a.png)
