### PR TITLE
Replace class indication in opponent's deck name with class icon in decktracker

### DIFF
--- a/core/src/css/component/decktracker/overlay/decktracker-deck-name.component.scss
+++ b/core/src/css/component/decktracker/overlay/decktracker-deck-name.component.scss
@@ -10,6 +10,13 @@
 	padding-right: 10px;
 	z-index: 1;
 
+	.class-image {
+		width: 25px;
+		height: 25px;
+		clip-path: circle(15px at 50% 50%);
+		margin-right: 2px;
+	}
+
 	span {
 		font-family: Sumana;
 		font-style: normal;

--- a/core/src/js/components/decktracker/overlay/decktracker-deck-name.component.ts
+++ b/core/src/js/components/decktracker/overlay/decktracker-deck-name.component.ts
@@ -12,6 +12,7 @@ import { OverwolfService } from '../../../services/overwolf.service';
 	],
 	template: `
 		<div class="deck-name">
+			<img class="class-image" *ngIf="playerClassImage" [src]="playerClassImage" />
 			<span class="name" [helpTooltip]="deckName" [bindTooltipToGameWindow]="true">{{ deckName }}</span>
 			<copy-deckstring
 				*ngIf="deckstring && !missingInitialDeckstring"
@@ -34,6 +35,7 @@ export class DeckTrackerDeckNameComponent {
 	deckName: string;
 	deckstring: string;
 	copyText: string;
+	playerClassImage: string;
 	_tooltipPosition: CardTooltipPositionType;
 	missingInitialDeckstring: boolean;
 	side: 'player' | 'opponent';
@@ -47,13 +49,11 @@ export class DeckTrackerDeckNameComponent {
 			return;
 		}
 
+		this.playerClassImage = value.isOpponent ? `https://static.zerotoheroes.com/hearthstone/asset/firestone/images/deck/classes/${(value.hero.playerClass ?? 'neutral').toLowerCase()}.png` : null;
 		this.deckName =
 			value.name ||
 			(value.hero
-				? this.i18n.translateString(`decktracker.deck-name.player-name`, {
-						playerName: value.hero.playerName || value.hero.name,
-						playerClass: this.i18n.translateString(`global.class.${value.hero.playerClass}`),
-				  })
+				? value.hero.playerName || value.hero.name || this.i18n.translateString('decktracker.streamer-mode.opponent')
 				: this.i18n.translateString('decktracker.deck-name.unnamed-deck'));
 		this.deckstring = value.deckstring;
 		this.copyText = this.i18n.translateString('decktracker.deck-name.copy-deckstring-label');


### PR DESCRIPTION
Also add default values for opponent name and class

**Before:**

![2022-10-15_21-53-45 2](https://user-images.githubusercontent.com/43519401/196287987-14e6b387-6fa7-48f3-a4ac-bc301624dd90.png)
![2022-10-16_01-50-07 2](https://user-images.githubusercontent.com/43519401/196287180-5656666c-e915-497e-adec-5fac5ff3d3a8.png)
![2022-10-16_02-16-27](https://user-images.githubusercontent.com/43519401/196287027-867b27e5-ab0e-40b3-9c9b-dcd12570069c.png)

**After:**



![2022-10-16_22-47-58](https://user-images.githubusercontent.com/43519401/196286986-84ae786c-392d-4442-b9a9-090dff4eb76d.png)

![2022-10-18_00-01-58](https://user-images.githubusercontent.com/43519401/196286933-02bd02cf-a143-406d-98ee-7508a07291cc.png)