### PR TITLE
Fix display of neutral icon in mercs team widget

### DIFF
--- a/core/src/js/components/mercenaries/overlay/teams/mercenaries-team-mercenary.component.ts
+++ b/core/src/js/components/mercenaries/overlay/teams/mercenaries-team-mercenary.component.ts
@@ -62,7 +62,7 @@ export class MercenariesTeamMercenaryComponent {
 		this.cardImage = `url(https://static.zerotoheroes.com/hearthstone/cardart/tiles/${value.cardId}.jpg)`;
 		this.roleIcon =
 			!value.role || value.role === TagRole[TagRole.INVALID]
-				? null
+				? `https://static.zerotoheroes.com/hearthstone/asset/firestone/mercenaries_icon_golden_neutral.png`
 				: `https://static.zerotoheroes.com/hearthstone/asset/firestone/mercenaries_icon_golden_${value.role?.toLowerCase()}.png`;
 		this.name = value.cardId
 			? refMercenaryCard.name ?? this.i18n.translateString('mercenaries.team-widget.unrecognized-mercenary')


### PR DESCRIPTION
**Before:**

![2022-10-17_13-05-26 2](https://user-images.githubusercontent.com/43519401/197779005-46374696-7a97-44ae-b122-68bd1a5e81a4.png)

**After:**

![2022-10-25_15-37-46](https://user-images.githubusercontent.com/43519401/197778693-cc8b1577-81ef-4320-903c-ec384572a461.png)
