### PR TITLE
Fix incorrect cooldown of some mercs abilities

### DIFF
--- a/core/src/js/services/mercenaries/parser/mercenaries-ability-revealed-parser.ts
+++ b/core/src/js/services/mercenaries/parser/mercenaries-ability-revealed-parser.ts
@@ -41,7 +41,7 @@ export class MercenariesAbilityRevealedParser implements MercenariesParser {
 			entityId: entityId,
 			cardId: cardId,
 			cooldown: event.additionalData.abilityCooldownConfig ?? refAbilityCard.mercenaryAbilityCooldown,
-			cooldownLeft: event.additionalData.abilityCurrentCooldown ?? refAbilityCard.mercenaryAbilityCooldown,
+			cooldownLeft: 0,
 			level: getMercCardLevel(cardId),
 			speed: isPassiveMercsTreasure(cardId, this.allCards)
 				? null

--- a/core/src/js/services/mercenaries/parser/mercenaries-hero-revealed-parser.ts
+++ b/core/src/js/services/mercenaries/parser/mercenaries-hero-revealed-parser.ts
@@ -88,7 +88,7 @@ export class MercenariesHeroRevealedParser implements MercenariesParser {
 						cardId: refCard.id,
 						level: refTier.tier,
 						cooldown: refCard.mercenaryAbilityCooldown ?? 0,
-						cooldownLeft: Math.max(0, (refCard.mercenaryAbilityCooldown ?? 0) - turnsElapsed),
+						cooldownLeft: 0,
 						speed: refCard.cost ?? 0,
 						totalUsed: null,
 						isTreasure: false,


### PR DESCRIPTION
Fix incorrect cooldown of Garona's and Eudora's Starts off cooldown abilities and Long'xin's, Holmes', Bwonsamdi's, Khadgar's, Natalie's abilities when they have equipment interacting with cooldown. 

Initially, cooldown of abilities should be 0, if it actually differs from zero, then the MERCENARIES_COOLDOWN_UPDATED event occurs.

**Before:**

![2022-10-29_15-47-51](https://user-images.githubusercontent.com/43519401/198832363-a272cbcf-0fe2-4c6f-8254-6aab583daa93.png)


**After:**

![2022-10-29_15-28-44](https://user-images.githubusercontent.com/43519401/198832365-2586ebdc-2539-43b3-b5a2-0388c724f99e.png)


