### PR TITLE
Fix incorrect equipment tier in out of combat team widget

### DIFF
--- a/core/src/js/components/mercenaries/overlay/teams/mercenaries-out-of-combat-player-team.component.ts
+++ b/core/src/js/components/mercenaries/overlay/teams/mercenaries-out-of-combat-player-team.component.ts
@@ -106,8 +106,9 @@ export class MercenariesOutOfCombatPlayerTeamComponent
 										const refEquipment = refMerc.equipments?.find(
 											(e) => e.equipmentId === equip.Id,
 										);
+										const refTier = refEquipment.tiers.find((t) => t.tier === equip.Tier);
 										return BattleEquipment.create({
-											cardId: this.allCards.getCardFromDbfId(refEquipment?.cardDbfId)?.id,
+											cardId: this.allCards.getCard(refTier?.cardDbfId)?.id,
 											level: equip.Tier,
 										});
 									})


### PR DESCRIPTION
**Before:**

![2022-11-02_15-24-28](https://user-images.githubusercontent.com/43519401/199491655-ed56ae6b-11ec-4140-a3cc-73eb189cace8.png)

**After:**

![2022-11-02_15-16-49](https://user-images.githubusercontent.com/43519401/199491671-dd2fef4e-a5c3-414a-8795-cd90d23f3128.png)
