### PR TITLE
Don't display Discover abilities in action queue

### DIFF
--- a/core/src/js/services/mercenaries/mercenaries-store.service.ts
+++ b/core/src/js/services/mercenaries/mercenaries-store.service.ts
@@ -160,7 +160,7 @@ export class MercenariesStoreService {
 			new MercenariesTeamPlayerManualCloseParser(),
 			new MercenariesTeamOpponentManualCloseParser(),
 
-			new MercenariesAbilityQueuedParser(),
+			new MercenariesAbilityQueuedParser(this.allCards),
 			new MercenariesAbilityUnqueuedParser(),
 		];
 		this.parsers = {};


### PR DESCRIPTION
We can't tell from game events which ability is selected when Discover ability is queued, so we shouldn't display such abilities at all.

![2022-11-06_02-13-25](https://user-images.githubusercontent.com/43519401/200145835-310c4b1f-89d9-4f9c-9c65-78a345bf45a8.png)
