### PR TITLE
Fix empty states in duels hero and treasure tabs

### DIFF
--- a/core/src/css/component/duels/desktop/duels-empty-state.component.scss
+++ b/core/src/css/component/duels/desktop/duels-empty-state.component.scss
@@ -3,6 +3,7 @@
 	display: flex;
 	align-items: center;
 	justify-content: center;
+	height: 100%;
 }
 
 .empty-state {

--- a/core/src/js/components/duels/desktop/duels-hero-stats.component.ts
+++ b/core/src/js/components/duels/desktop/duels-hero-stats.component.ts
@@ -15,7 +15,9 @@ import { AbstractSubscriptionComponent } from '../../abstract-subscription.compo
 	],
 	template: `
 		<div *ngIf="stats$ | async as stats; else emptyState" class="duels-hero-stats" scrollable>
-			<duels-hero-stat-vignette *ngFor="let stat of stats" [stat]="stat"></duels-hero-stat-vignette>
+			<ng-container *ngIf="stats?.length; else emptyState">
+				<duels-hero-stat-vignette *ngFor="let stat of stats" [stat]="stat"></duels-hero-stat-vignette>
+			</ng-container>
 		</div>
 		<ng-template #emptyState>
 			<duels-empty-state></duels-empty-state>

--- a/core/src/js/components/duels/desktop/duels-treasure-stat.component.ts
+++ b/core/src/js/components/duels/desktop/duels-treasure-stat.component.ts
@@ -25,7 +25,9 @@ import { AbstractSubscriptionComponent } from '../../abstract-subscription.compo
 	],
 	template: `
 		<div *ngIf="stats$ | async as stats; else emptyState" class="duels-treasure-stats" scrollable>
-			<duels-hero-stat-vignette *ngFor="let stat of stats" [stat]="stat"></duels-hero-stat-vignette>
+			<ng-container *ngIf="stats?.length; else emptyState">
+				<duels-hero-stat-vignette *ngFor="let stat of stats" [stat]="stat"></duels-hero-stat-vignette>
+			</ng-container>
 		</div>
 		<ng-template #emptyState>
 			<duels-empty-state></duels-empty-state>


### PR DESCRIPTION
**Before:**

![2022-11-09_01-33-09](https://user-images.githubusercontent.com/43519401/200690487-247b532d-4bea-4aee-b25b-b24fe01675f6.png)


**After:**

![2022-11-09_01-21-30](https://user-images.githubusercontent.com/43519401/200689562-4b952ca2-38a5-443f-b69f-09cae0bd85bb.png)
