### PR TITLE
Add base support for Death Knight class

### DIFF
--- a/core/src/js/components/decktracker/main/deckbuilder/constructed-deckbuilder-class.component.ts
+++ b/core/src/js/components/decktracker/main/deckbuilder/constructed-deckbuilder-class.component.ts
@@ -35,17 +35,17 @@ export class ConstructedDeckbuilderClassComponent extends AbstractSubscriptionCo
 	rows = [
 		{
 			id: 'top',
-			items: 3,
+			items: 4,
 			startIndex: 0,
 		},
 		{
 			id: 'middle',
-			items: 4,
-			startIndex: 3,
+			items: 3,
+			startIndex: 4,
 		},
 		{
 			id: 'bottom',
-			items: 3,
+			items: 4,
 			startIndex: 7,
 		},
 	];

--- a/core/src/js/models/collection/filter-types.ts
+++ b/core/src/js/models/collection/filter-types.ts
@@ -11,6 +11,7 @@ export type CollectionCardOwnedFilterType =
 	| 'notcompleted';
 export type CollectionCardClassFilterType =
 	| 'all'
+	| 'deathknight'
 	| 'demonhunter'
 	| 'druid'
 	| 'hunter'

--- a/core/src/js/services/hs-utils.ts
+++ b/core/src/js/services/hs-utils.ts
@@ -20,6 +20,7 @@ import { LocalizationFacadeService } from './localization-facade.service';
 export const CARDS_VERSION = '';
 
 export const classes = [
+	'deathknight',
 	'demonhunter',
 	'druid',
 	'hunter',
@@ -32,6 +33,7 @@ export const classes = [
 	'warrior',
 ];
 export const classesForPieChart = [
+	'deathknight',
 	'rogue',
 	'druid',
 	'hunter',
@@ -50,6 +52,8 @@ export const formatClass = (playerClass: string, i18n: { translateString: (strin
 
 export const colorForClass = (playerClass: string): string => {
 	switch (playerClass) {
+		case 'deathknight':
+			return '#6aaeb9'
 		case 'demonhunter':
 			return '#123B17';
 		case 'druid':
@@ -1012,6 +1016,8 @@ export const COUNTERSPELLS = [
 
 export const getDefaultHeroDbfIdForClass = (playerClass: string): number => {
 	switch (playerClass?.toLowerCase()) {
+		case 'deathknight':
+			return 93448;
 		case 'demonhunter':
 			return 56550;
 		case 'druid':


### PR DESCRIPTION
You should also upload class icon at
https://static.zerotoheroes.com/hearthstone/asset/firestone/images/deck/classes/deathknight.png

![deathknight](https://user-images.githubusercontent.com/43519401/201495958-4e94bf66-2206-4b1b-afff-eff57376c68b.png)
