### PR TITLE
Localize Rating title in bgs-hero-portrait component and imrove display

### DIFF
--- a/core/src/css/component/battlegrounds/bgs-hero-portrait.component.scss
+++ b/core/src/css/component/battlegrounds/bgs-hero-portrait.component.scss
@@ -39,23 +39,36 @@
 .rating {
 	background: url(https://static.zerotoheroes.com/hearthstone/asset/firestone/images/rating_banner.png);
 	position: absolute;
-	width: 89%;
+	width: 100%;
 	height: 50%;
 	background-size: contain;
 	background-repeat: no-repeat;
-	bottom: -40%;
+	bottom: -45%;
 	display: flex;
+	flex-direction: column;
 	align-items: center;
 	justify-content: center;
 
+	.title { 
+		margin-bottom: -12px;
+    	margin-top: -15px;
+		font-family: 'Sumana';
+		font-weight: bolder;
+		font-size: 11px;
+		color: #d968f1;
+		text-shadow: -1px -1px 0 #000, 0px -1px 0 #000, 1px -1px 0 #000, -1px 1px 0 #000, 0px 1px 0 #000, 1px 1px 0 #000;
+	}
+
 	.value {
-		font-family: Passion One;
+		margin-bottom: -10px;
+    	margin-top: -15px;
+		font-family: 'Sumana';
 		font-style: normal;
-		font-weight: normal;
+		font-weight: bolder;
 		font-size: 20px;
 		text-align: center;
 		color: var(--color-1);
-		text-shadow: -2px -2px 0 #000, 0px -2px 0 #000, 2px -2px 0 #000, -2px 2px 0 #000, 0px 2px 0 #000, 2px 2px 0 #000;
+		text-shadow: -1px -1px 0 #000, 0px -1px 0 #000, 1px -1px 0 #000, -1px 1px 0 #000, 0px 1px 0 #000, 1px 1px 0 #000;
 	}
 }
 

--- a/core/src/js/components/battlegrounds/bgs-hero-portrait.component.ts
+++ b/core/src/js/components/battlegrounds/bgs-hero-portrait.component.ts
@@ -25,7 +25,8 @@ import { ChangeDetectionStrategy, ChangeDetectorRef, Component, Input, ViewRef }
 				<div class="value">{{ _health }}</div>
 			</div>
 			<div class="rating" *ngIf="rating != null">
-				<div class="value">{{ rating?.toLocaleString('en-US') }}</div>
+				<div class="title" [owTranslate]="'app.battlegrounds.personal-stats.hero.rating'"></div>
+				<div class="value">{{ rating }}</div>
 			</div>
 		</div>
 	`,


### PR DESCRIPTION
Would you mind replacing [banner image](https://static.zerotoheroes.com/hearthstone/asset/firestone/images/rating_banner.png) with this one?

![rating_banner 4](https://user-images.githubusercontent.com/43519401/201550627-9cf83b5b-8a78-4c92-b953-2d92be5bdca7.png)


**Before:**

![2022-11-14_02-45-47](https://user-images.githubusercontent.com/43519401/201550898-f51296b3-ca45-4796-83bd-39e5b06f6f17.png)

**After:**

![2022-11-14_02-13-15](https://user-images.githubusercontent.com/43519401/201550656-aa30af38-2c30-46f6-8593-3521cc0bbf60.png)
![2022-11-14_02-02-08](https://user-images.githubusercontent.com/43519401/201550659-f87a6438-e8ff-48c9-9989-688685b981a6.png)
