### PR TITLE
Improve display of match-details component when zoomed level increased

### DIFF
--- a/core/src/css/component/battlegrounds/bgs-player-capsule.component.scss
+++ b/core/src/css/component/battlegrounds/bgs-player-capsule.component.scss
@@ -83,6 +83,7 @@
 		border-image-slice: 1 1 1 0;
 		border-left: none;
 		width: 100%;
+		overflow: hidden;
 		display: flex;
 		padding-bottom: 5px;
 		padding-top: 10px;

--- a/core/src/css/component/replays/replay-info/replay-info-battlegrounds.component.scss
+++ b/core/src/css/component/replays/replay-info/replay-info-battlegrounds.component.scss
@@ -1,4 +1,6 @@
 .battlegrounds {
+	overflow: hidden;
+	
 	.group.result {
 		width: 55px;
 		display: flex;


### PR DESCRIPTION
**Before:**

![2022-11-14_03-07-27](https://user-images.githubusercontent.com/43519401/201552408-022a1951-5c59-4d35-b6a1-c3c25a0be315.png)


**After:**

![2022-11-14_03-06-39](https://user-images.githubusercontent.com/43519401/201552405-db4d8712-2d30-460f-88dd-2e4675ac9110.png)
