### PR TITLE
Updated Out of Cards connections to Out of Games

### DIFF
--- a/libs/legacy/feature-shell/src/lib/js/components/settings/general/settings-general-third-party.component.ts
+++ b/libs/legacy/feature-shell/src/lib/js/components/settings/general/settings-general-third-party.component.ts
@@ -106,7 +106,7 @@ export class SettingsGeneralThirdPartyComponent
 	implements AfterContentInit, OnDestroy
 {
 	oocLoggedIn$: Observable<boolean>;
-	oocLoginUrl = `https://outof.cards/oauth/authorize/?client_id=oqEn7ONIAOmugFTjFQGe1lFSujGxf3erhNDDTvkC&response_type=code&scope=hearthcollection&redirect_uri=https://www.firestoneapp.com/ooc-login.html`;
+	oocLoginUrl = `https://outof.games/oauth/authorize/?client_id=oqEn7ONIAOmugFTjFQGe1lFSujGxf3erhNDDTvkC&response_type=code&scope=hearthcollection&redirect_uri=https://www.firestoneapp.com/ooc-login.html`;
 
 	vs = {
 		title: 'Vicious Syndicate',
@@ -120,10 +120,10 @@ export class SettingsGeneralThirdPartyComponent
 		toggleLabel: this.i18n.translateString('settings.general.third-party.vs.toggle-label'),
 	};
 	ooc = {
-		title: 'Out of Cards',
+		title: 'Out of Games',
 		icon: 'https://static.zerotoheroes.com/hearthstone/asset/firestone/images/third-party/out-of-cards.png',
 		pitch: this.i18n.translateString('settings.general.third-party.ooc.pitch', {
-			websiteLink: `<a href="https://outof.cards/hearthstone/" target="_blank">${this.i18n.translateString(
+			websiteLink: `<a href="https://outof.games/hearthstone/" target="_blank">${this.i18n.translateString(
 				'settings.general.third-party.ooc.website-link',
 			)}</a>`,
 		}),

--- a/libs/legacy/feature-shell/src/lib/js/components/third-party/out-of-cards-callback.component.ts
+++ b/libs/legacy/feature-shell/src/lib/js/components/third-party/out-of-cards-callback.component.ts
@@ -34,7 +34,7 @@ export class OutOfCardsCallbackComponent implements AfterViewInit {
 			window.close();
 		} else {
 			window.location.replace(
-				`https://outof.cards/oauth/authorize/?client_id=oqEn7ONIAOmugFTjFQGe1lFSujGxf3erhNDDTvkC&response_type=code&scope=hearthcollection&redirect_uri=https://www.firestoneapp.com/ooc-login.html`,
+				`https://outof.games/oauth/authorize/?client_id=oqEn7ONIAOmugFTjFQGe1lFSujGxf3erhNDDTvkC&response_type=code&scope=hearthcollection&redirect_uri=https://www.firestoneapp.com/ooc-login.html`,
 			);
 		}
 	}

--- a/libs/legacy/feature-shell/src/lib/js/services/mainwindow/out-of-cards.service.ts
+++ b/libs/legacy/feature-shell/src/lib/js/services/mainwindow/out-of-cards.service.ts
@@ -10,7 +10,7 @@ import { OwNotificationsService } from '../notifications.service';
 import { MemoryInspectionService } from '../plugins/memory-inspection.service';
 import { PreferencesService } from '../preferences.service';
 
-const COLLECTION_UPLOAD = `https://outof.cards/api/hearthstone/collection/import/`;
+const COLLECTION_UPLOAD = `https://outof.games/api/hearthstone/collection/import/`;
 const REFRESH_DEBOUNCE_MS = 30 * 1000;
 
 @Injectable()
@@ -71,7 +71,7 @@ export class OutOfCardsService {
 
 	public async generateToken(code: string): Promise<OutOfCardsToken> {
 		const requestString = `code=${code}&grant_type=authorization_code&redirect_uri=https://www.firestoneapp.com/ooc-login.html&client_id=oqEn7ONIAOmugFTjFQGe1lFSujGxf3erhNDDTvkC`;
-		const token: OutOfCardsToken = await this.api.callPostApi('https://outof.cards/oauth/token/', requestString, {
+		const token: OutOfCardsToken = await this.api.callPostApi('https://outof.games/oauth/token/', requestString, {
 			contentType: 'application/x-www-form-urlencoded',
 		});
 		if (!token) {
@@ -161,7 +161,7 @@ export class OutOfCardsService {
 
 	private async refreshToken(refresh_token: string): Promise<OutOfCardsToken> {
 		const requestString = `grant_type=refresh_token&refresh_token=${refresh_token}&client_id=oqEn7ONIAOmugFTjFQGe1lFSujGxf3erhNDDTvkC&scope=hearthcollection`;
-		const token: OutOfCardsToken = await this.api.callPostApi('https://outof.cards/oauth/token/', requestString, {
+		const token: OutOfCardsToken = await this.api.callPostApi('https://outof.games/oauth/token/', requestString, {
 			contentType: 'application/x-www-form-urlencoded',
 		});
 		if (!token) {

--- a/overwolf/manifest.json
+++ b/overwolf/manifest.json
@@ -223,7 +223,7 @@
 				"https://api.twitch.tv",
 				"http://*.twitch.tv",
 				"https://*.twitch.tv",
-				"https://*.outof.cards",
+				"https://*.outof.games",
 				"https://www.googletagmanager.com",
 				"https://*.pastebin.com"
 			]


### PR DESCRIPTION
Out of Cards has transitions to Out of Games and so the URLs need to be moved over to the new service.

The `ooc.pitch` will also need to be updated to reflect the name change to Out of Games, the rest can remain the same for the third-party.