### PR TITLE
Fix 0-pad for minutes place if totalRunTime >= 1h

### DIFF
--- a/libs/stats/common/src/lib/components/replay-info-generic-2.component.ts
+++ b/libs/stats/common/src/lib/components/replay-info-generic-2.component.ts
@@ -238,7 +238,10 @@ export const extractTime = (durationInSeconds: number): { min: string; sec: stri
 };
 export const extractTimeWithHours = (durationInSeconds: number): { min: string; sec: string; hrs: string } => {
 	const hours = `${Math.floor(durationInSeconds / 3600)}`;
-	const minutes = `${Math.floor((durationInSeconds % 3600) / 60)}`;
+
+	const minutes = hours === '0' 
+		? `${Math.floor((durationInSeconds % 3600) / 60)}` 
+		: `${Math.floor((durationInSeconds % 3600) / 60)}`.padStart(2, '0');
 	const seconds = `${durationInSeconds % 60}`.padStart(2, '0');
 	return {
 		min: minutes,


### PR DESCRIPTION
Fixes runtime displays formatted at an hour+ not 0 padding.

1:6 hours should actually be 1:06 hours, 3:9 hours should actually be 3:09 hours, etc.

Does not include the 0 place if hours = 0 so we don't get clunky 07:53 minutes and just 7:53 minutes instead.

Previous:
![image](https://github.com/user-attachments/assets/1e614327-0c37-482c-993d-22bfccf5939a)

Current:
![image](https://github.com/user-attachments/assets/3f15c6af-79cf-4e97-896a-f2721a53b6f3)

