### PR TITLE
Fix naga giant label formatting

### DIFF
--- a/libs/game-state/src/lib/counters/impl/naga-giant.ts
+++ b/libs/game-state/src/lib/counters/impl/naga-giant.ts
@@ -37,6 +37,18 @@ export class NagaGiantCounterDefinitionV2 extends CounterDefinitionV2<{
 		super();
 	}
 
+	protected override formatValue(
+		value: { spellsPlayedThisMatch: ShortCard[]; manaSpentOnSpellsThisMatch: number } | null | undefined,
+	): null | undefined | number | string {
+		const giantBaseCost = this.allCards.getCard(CardIds.NagaGiant).cost!;
+		if (!value) {
+			return `${giantBaseCost}`;
+		}
+		const totalCostReduction = value.manaSpentOnSpellsThisMatch ?? 0;
+		const costAfterReduction = Math.max(0, giantBaseCost - totalCostReduction);
+		return `${costAfterReduction}`;
+	}
+
 	protected override tooltip(side: 'player' | 'opponent', gameState: GameState): string | null {
 		const value = this[side]?.value(gameState);
 		if (!value) {


### PR DESCRIPTION
Overrides existing formatting for Naga Giant to present the current cost.

We discussed formatting it like abyssal curses, but I think it's better to format it that way it's consistent with Ceaseless (AKA Ceaseless now costs X, and only showing X)

Before:
![df71fbaab6a895b4fc188c0203ef1fc0](https://github.com/user-attachments/assets/ff578ec8-bad1-4fa6-8926-8af3b13ecc71)

After:
![b5e8af1d1108068ae3b22893d5e23d2b](https://github.com/user-attachments/assets/c30bbdf4-29f8-47a1-bd06-35ac9c5b226e)

Happy to adjust as you see fit.