### PR TITLE
Update dynamic pools for s56 arena

### DIFF
--- a/libs/game-state/src/lib/related-cards/dynamic-pools.ts
+++ b/libs/game-state/src/lib/related-cards/dynamic-pools.ts
@@ -68,8 +68,38 @@ export const getDynamicRelatedCardIds = (
 				(c) =>
 					!isValidSet(c.set.toLowerCase() as SetId, GameFormat.FT_STANDARD, options.gameType) &&
 					c?.type?.toUpperCase() === CardType[CardType.WEAPON] &&
-					fromClass(c, CardClass.PALADIN),
+					c.classes?.includes(CardClass[CardClass.PALADIN]),
 			);
+		case CardIds.ErodedSediment_WW_428:
+			return filterCards(
+				allCards,
+				{ ...options, format: GameFormat.FT_WILD },
+				cardId,
+				(c) =>
+					!isValidSet(c.set.toLowerCase() as SetId, GameFormat.FT_STANDARD, options.gameType) &&
+					hasCorrectTribe(c, Race.ELEMENTAL),
+			);
+		case CardIds.WaveOfNostalgia_MIS_701:
+			return filterCards(
+				allCards,
+				{ ...options, format: GameFormat.FT_WILD },
+				cardId,
+				(c) =>
+					c?.type?.toUpperCase() === CardType[CardType.MINION] &&
+					!isValidSet(c.set.toLowerCase() as SetId, GameFormat.FT_STANDARD, options.gameType) &&
+					c?.rarity?.toUpperCase() === CardRarity[CardRarity.LEGENDARY],
+			);
+		case CardIds.Botface_TOY_906:
+			// TODO: Fix these minis not showing up properly (are minis tagged properly?)
+			// TODO: Confirm if Botface can generate Boom Wrench - if not, add minion tag
+			return filterCards(
+				allCards,
+				{ ...options, format: GameFormat.FT_WILD },
+				cardId,
+				(c) => 
+					c?.mechanics?.includes(GameTag[GameTag.MINI]),
+			);
+	
 		case CardIds.EmergencyMeeting_GDB_119:
 			return [
 				...CREWMATES,
@@ -130,6 +160,229 @@ const getDynamicFilters = (
 	},
 ): ((ref: ReferenceCard) => boolean | undefined) | ((ref: ReferenceCard) => boolean)[] | undefined => {
 	switch (cardId) {
+		case CardIds.ShiftySophomore:
+			return (c) =>
+				c.mechanics?.includes(GameTag[GameTag.COMBO]);
+		case CardIds.BloodsailRecruiter_VAC_430:
+			return (c) =>
+				c?.type?.toUpperCase() === CardType[CardType.MINION] &&
+				hasCorrectTribe(c, Race.PIRATE);
+		case CardIds.ObserverOfMysteries_TOY_520:
+			return (c) =>
+				c?.type?.toUpperCase() === CardType[CardType.SPELL] &&
+				c?.mechanics?.includes(GameTag[GameTag.SECRET]);
+		case CardIds.DelayedProduct_MIS_305:
+			return (c) =>
+				c?.type?.toUpperCase() === CardType[CardType.MINION] &&
+				(c?.cost ?? 0) >= 8 &&
+				canBeDiscoveredByClass(c, options.currentClass);
+		case CardIds.CraftersAura_TOY_808:
+			return (c) =>
+				c?.type?.toUpperCase() === CardType[CardType.MINION] &&
+				(c?.cost ?? 0) === 6;
+		case CardIds.SpotTheDifference_TOY_374:
+		case CardIds.IncredibleValue_TOY_046:
+			return (c) =>
+				c?.type?.toUpperCase() === CardType[CardType.MINION] &&
+				(c?.cost ?? 0) === 4 &&
+				canBeDiscoveredByClass(c, options.currentClass);
+		case CardIds.HiddenObjects_TOY_037:
+			return (c) =>
+				c?.type?.toUpperCase() === CardType[CardType.SPELL] && 
+				c?.mechanics?.includes(GameTag[GameTag.SECRET]) &&
+				c.classes?.includes(CardClass[CardClass.MAGE]);
+		case CardIds.WindowShopper_TOY_652:
+			return (c) =>
+				c?.type?.toUpperCase() === CardType[CardType.MINION] &&
+				hasCorrectTribe(c, Race.DEMON) &&
+				canBeDiscoveredByClass(c, options.currentClass);
+		case CardIds.BlindBox_TOY_643:
+			return (c) =>
+				c?.type.toUpperCase() === CardType[CardType.MINION] &&
+				hasCorrectTribe(c, Race.DEMON);
+		case CardIds.SilkStitching_TOY_822:
+			return (c) =>
+				c?.type.toUpperCase() === CardType[CardType.SPELL] &&
+				(c?.cost ?? 0) <= 4 &&
+				canBeDiscoveredByClass(c, options.currentClass);
+		case CardIds.ChaoticTendril_YOG_514:
+			return (c) =>
+				c?.type.toUpperCase() === CardType[CardType.SPELL] &&
+				(c?.cost ?? 0) === options.deckState.chaoticTendrilsPlayedThisMatch + 1;
+		case CardIds.RunesOfDarkness_YOG_511:
+			return (c) =>
+				c?.type?.toUpperCase() === CardType[CardType.WEAPON] &&
+				canBeDiscoveredByClass(c, options.currentClass);
+		case CardIds.OnceUponATime_TOY_506:
+			return (c) =>
+				c?.type?.toUpperCase() === CardType[CardType.MINION] &&
+				(hasCorrectTribe(c, Race.BEAST) || 
+					hasCorrectTribe(c, Race.DRAGON) || 
+					hasCorrectTribe(c, Race.ELEMENTAL) || 
+					hasCorrectTribe(c, Race.MURLOC)) &&
+				(c?.cost ?? 0) == 3;
+		case CardIds.PartnerAssignment:
+			return (c) => 
+				c?.type?.toUpperCase() === CardType[CardType.MINION] &&
+				hasCorrectTribe(c, Race.BEAST) &&
+				((c?.cost ?? 0) === 2 || (c?.cost ?? 0) == 3);
+		case CardIds.FoolsGold_DEEP_022:
+			return (c) =>
+				c?.type?.toUpperCase() === CardType[CardType.MINION] &&
+				(hasCorrectTribe(c, Race.PIRATE) || hasCorrectTribe(c, Race.ELEMENTAL)) &&
+				fromAnotherClass(c, options.currentClass);	
+		case CardIds.RitualOfTheNewMoon_EDR_461:
+			return (c) =>
+				c?.type?.toUpperCase() === CardType[CardType.MINION] &&
+				((c?.cost ?? 0) === 6 || (c?.cost ?? 0) == 3);
+		
+		case CardIds.GorillabotA3Core:	
+		case CardIds.GorillabotA3:
+			return (c) =>
+				c?.type?.toUpperCase() === CardType[CardType.MINION] &&
+				hasCorrectTribe(c, Race.MECH);
+		case CardIds.MismatchedFossils_DEEP_001:
+			return (c) =>
+				c?.type?.toUpperCase() === CardType[CardType.MINION] &&
+				(hasCorrectTribe(c, Race.BEAST) || 
+					hasCorrectTribe(c, Race.UNDEAD));
+		case CardIds.ObsidianRevenant_DEEP_005:
+			return (c) =>
+				c?.type?.toUpperCase() === CardType[CardType.MINION] &&
+				c?.mechanics?.includes(GameTag[GameTag.DEATHRATTLE]) &&
+				(c?.cost ?? 0) <= 3;
+		case CardIds.Mothership_TSC_645:
+			return (c) =>
+				c?.type?.toUpperCase() === CardType[CardType.MINION] &&
+				hasCorrectTribe(c, Race.MECH) &&
+				(c?.cost ?? 0) <= 3;
+		case CardIds.OasisOutlaws_WW_404:
+			return (c) =>
+				c?.type?.toUpperCase() === CardType[CardType.MINION] &&
+				hasCorrectTribe(c, Race.NAGA) &&
+				canBeDiscoveredByClass(c, options.currentClass);
+		case CardIds.CactusConstruct_WW_818:
+			return (c) =>
+				c?.type?.toUpperCase() === CardType[CardType.MINION] &&
+				(c?.cost ?? 0) === 2 &&
+				canBeDiscoveredByClass(c, options.currentClass);
+		case CardIds.SaddleUp_WW_812:
+			return (c) =>
+				c?.type?.toUpperCase() === CardType[CardType.MINION] &&
+				hasCorrectTribe(c, Race.BEAST) &&
+				(c?.cost ?? 0) <= 3;
+		case CardIds.ReliquaryResearcher_WW_432:
+			return (c) =>
+				c?.type?.toUpperCase() === CardType[CardType.SPELL] && 
+				c?.mechanics?.includes(GameTag[GameTag.SECRET]) &&
+				c.classes?.includes(CardClass[CardClass.MAGE]);
+		case CardIds.WishingWell_WW_415:
+		case CardIds.SneedsOldShredder_CORE_GVG_114:
+			return (c) =>
+				c?.type?.toUpperCase() === CardType[CardType.MINION] &&
+				c?.rarity?.toUpperCase() === CardRarity[CardRarity.LEGENDARY];
+		case CardIds.MaruutStonebinder_DEEP_037:
+			return (c) =>
+				c?.type?.toUpperCase() === CardType[CardType.MINION] &&
+				hasCorrectTribe(c, Race.ELEMENTAL);
+		case CardIds.WildernessPack_MIS_104:
+			return (c) =>
+				c?.type?.toUpperCase() === CardType[CardType.MINION] &&
+				hasCorrectTribe(c, Race.BEAST);		
+		case CardIds.TeachersPet:
+			return (c) =>
+				c?.type?.toUpperCase() === CardType[CardType.MINION] &&
+				hasCorrectTribe(c, Race.BEAST) &&
+				(c?.cost ?? 0) === 3;
+		case CardIds.PackKodo:
+			return (c) =>
+				c?.type?.toUpperCase() === CardType[CardType.MINION] &&
+				(hasCorrectTribe(c, Race.BEAST) ||
+					(c?.type?.toUpperCase() === CardType[CardType.SPELL] && 
+						c?.mechanics?.includes(GameTag[GameTag.SECRET])) ||
+					c?.type?.toUpperCase() === CardType[CardType.WEAPON]
+				) &&
+				canBeDiscoveredByClass(c, options.currentClass);
+		case CardIds.SchoolTeacher:
+			// TODO: Add nagaling token 
+			return (c) => 
+					(c?.type?.toUpperCase() === CardType[CardType.SPELL] &&
+					(c?.cost ?? 0) <= 3 &&
+					canBeDiscoveredByClass(c, options.currentClass));
+		case CardIds.EverythingMustGo_TOY_519:
+			return (c) =>
+				c?.type?.toUpperCase() === CardType[CardType.MINION] &&
+				(c?.cost ?? 0) === 4;
+		case CardIds.AzsharanScroll:
+		case CardIds.AzsharanScroll_SunkenScrollToken: 
+			return (c) =>
+				c?.type?.toUpperCase() === CardType[CardType.SPELL] &&
+				c?.classes?.includes(options.currentClass.toUpperCase()) &&
+				(c?.spellSchool?.includes(SpellSchool[SpellSchool.FIRE]) || 
+					c?.spellSchool?.includes(SpellSchool[SpellSchool.FROST]) ||
+					c?.spellSchool?.includes(SpellSchool[SpellSchool.NATURE]))
+		case CardIds.Peon_BAR_022:
+		case CardIds.OnyxMagescribe:
+			return (c) =>
+				c?.type?.toUpperCase() === CardType[CardType.SPELL] &&
+				c?.classes?.includes(options.currentClass.toUpperCase());
+		case CardIds.Jackpot:
+			return (c) =>
+				c?.type?.toUpperCase() === CardType[CardType.SPELL] &&
+				(c?.cost ?? 0) >= 5 &&
+				fromAnotherClass(c, options.currentClass);
+		case CardIds.SunkenSweeper:
+			return (c) =>
+				c?.type?.toUpperCase() === CardType[CardType.MINION] &&
+				hasCorrectTribe(c, Race.MECH);
+		case CardIds.SubmergedSpacerock:
+			return (c) =>
+				c?.type?.toUpperCase() === CardType[CardType.SPELL] &&
+				c?.spellSchool?.includes(SpellSchool[SpellSchool.ARCANE]) &&
+				c.classes?.includes(CardClass[CardClass.MAGE]);
+		case CardIds.SavoryDeviateDelight:
+			return (c) =>
+				c?.type?.toUpperCase() === CardType[CardType.MINION] &&
+				(hasCorrectTribe(c, Race.PIRATE) ||
+					c.mechanics?.includes(GameTag[GameTag.STEALTH]));
+		case CardIds.PlaguedProtodrake:
+			return (c) =>
+				c?.type?.toUpperCase() === CardType[CardType.MINION] &&
+				(c?.cost ?? 0) === 7;
+		case CardIds.ExarchHataaru_GDB_136:
+			return (c) =>
+				c?.type?.toUpperCase() === CardType[CardType.SPELL] &&
+				canBeDiscoveredByClass(c, options.currentClass);
+		case CardIds.InstructorFireheart:
+			return (c) =>
+				c?.type?.toUpperCase() === CardType[CardType.SPELL] &&
+				(c.cost ?? 0) >= 1 &&
+				canBeDiscoveredByClass(c, options.currentClass);
+		case CardIds.TrickTotem_SCH_537:
+			return (c) =>
+				c?.type?.toUpperCase() === CardType[CardType.SPELL] &&
+				(c.cost ?? 0) <= 3
+		case CardIds.WandThief_SCH_350:
+			return (c) =>
+				c?.type?.toUpperCase() === CardType[CardType.SPELL] &&
+				c.classes?.includes(CardClass[CardClass.MAGE])
+		case CardIds.SunsetVolley_WW_427:
+			return (c) =>
+				c?.type?.toUpperCase() === CardType[CardType.MINION] &&
+				(c?.cost ?? 0) === 10;
+		case CardIds.TrainingSession_NX2_029:
+		case CardIds.HikingTrail_VAC_517:
+		case CardIds.StonehillDefender_Core_UNG_072:
+		case CardIds.IKnowAGuy_CORE_WON_350:
+			return (c) =>
+				c?.type?.toUpperCase() === CardType[CardType.MINION] &&
+				hasMechanic(c, GameTag.TAUNT) &&
+				canBeDiscoveredByClass(c, options.currentClass);
+		case CardIds.StandardizedPack_MIS_705:
+		case CardIds.InFormation:
+			return (c) =>
+				c?.type?.toUpperCase() === CardType[CardType.MINION] &&
+				hasMechanic(c, GameTag.TAUNT);
 		case CardIds.SmokeBomb_FIR_920:
 			return (c) =>
 				canBeDiscoveredByClass(c, options.currentClass) &&
@@ -157,11 +410,13 @@ const getDynamicFilters = (
 			return (c) => hasCorrectTribe(c, Race.DEMON) && canBeDiscoveredByClass(c, options.currentClass);
 		case CardIds.EmberscarredWhelp_FIR_927:
 			return (c) => canBeDiscoveredByClass(c, options.currentClass) && c.cost === 5;
+		case CardIds.Cremate_FIR_900:
+			return (c) => c.type?.toUpperCase() === CardType[CardType.MINION] && canBeDiscoveredByClass(c, options.currentClass);
 		case CardIds.InfernoHerald_FIR_913:
 			return (c) => hasCorrectTribe(c, Race.ELEMENTAL);
+		case CardIds.FarmHand_WW_358:
 		case CardIds.ToysnatchingGeist_MIS_006:
 		case CardIds.ToysnatchingGeist_ToysnatchingGeistToken_MIS_006t:
-			return (c) => hasCorrectTribe(c, Race.UNDEAD) && canBeDiscoveredByClass(c, options.currentClass);
 		case CardIds.RiteOfAtrocity_EDR_811:
 			return (c) => hasCorrectTribe(c, Race.UNDEAD) && canBeDiscoveredByClass(c, options.currentClass);
 		case CardIds.SweetenedSnowflurry_TOY_307:
@@ -171,8 +426,7 @@ const getDynamicFilters = (
 		case CardIds.SparkOfLife_EDR_872:
 			return (c) =>
 				c?.type?.toUpperCase() === CardType[CardType.SPELL] &&
-				(c.classes?.includes(CardClass[CardClass.MAGE]) || c.classes?.includes(CardClass[CardClass.DRUID])) &&
-				canBeDiscoveredByClass(c, options.currentClass);
+				(c.classes?.includes(CardClass[CardClass.MAGE]) || c.classes?.includes(CardClass[CardClass.DRUID]))
 		case CardIds.BabblingBookcase_CORE_EDR_001:
 			return (c) =>
 				c?.type?.toUpperCase() === CardType[CardType.SPELL] && c.classes?.includes(CardClass[CardClass.MAGE]);
@@ -203,13 +457,11 @@ const getDynamicFilters = (
 				hasCorrectTribe(c, Race.DEMON) &&
 				(c.cost ?? 0) >= 5 &&
 				canBeDiscoveredByClass(c, options.currentClass);
-		case CardIds.Ysondre_EDR_465:
-			return (c) => c?.type?.toUpperCase() === CardType[CardType.MINION] && hasCorrectTribe(c, Race.DRAGON);
+		
 		case CardIds.Photosynthesis_EDR_848:
 			return (c) =>
 				c?.type?.toUpperCase() === CardType[CardType.SPELL] && c.classes?.includes(CardClass[CardClass.DRUID]);
-		case CardIds.WardOfEarth_EDR_060:
-			return (c) => c?.type?.toUpperCase() === CardType[CardType.MINION] && c.cost === 5;
+		
 		case CardIds.Symbiosis_EDR_273:
 			return (c) => hasMechanic(c, GameTag.CHOOSE_ONE) && fromAnotherClass(c, options.currentClass);
 		case CardIds.DaydreamingPixie_EDR_530:
@@ -221,8 +473,11 @@ const getDynamicFilters = (
 				c?.type?.toUpperCase() === CardType[CardType.SPELL] &&
 				c?.spellSchool === SpellSchool[SpellSchool.NATURE] &&
 				canBeDiscoveredByClass(c, options.currentClass);
+		case CardIds.DragonTales_WW_821:
+		case CardIds.Ysondre_EDR_465:
 		case CardIds.SelenicDrake_EDR_462:
 			return (c) => c?.type?.toUpperCase() === CardType[CardType.MINION] && hasCorrectTribe(c, Race.DRAGON);
+		case CardIds.Howdyfin_WW_333:	
 		case CardIds.GnawingGreenfin_EDR_999:
 			return (c) => c?.type?.toUpperCase() === CardType[CardType.MINION] && hasCorrectTribe(c, Race.MURLOC);
 		case CardIds.TreacherousTormentor_EDR_102:
@@ -255,16 +510,14 @@ const getDynamicFilters = (
 				c?.type?.toUpperCase() === CardType[CardType.MINION] &&
 				(c.cost ?? 0) >= 5 &&
 				hasCorrectTribe(c, Race.DEMON);
-		case CardIds.FirstContact_GDB_864:
-			return (c) => c?.type?.toUpperCase() === CardType[CardType.MINION] && c?.cost === 1;
+		
 		case CardIds.AssimilatingBlight_GDB_478:
 			return (c) =>
 				c?.type?.toUpperCase() === CardType[CardType.MINION] &&
 				c?.cost === 3 &&
 				canBeDiscoveredByClass(c, options.currentClass) &&
 				hasMechanic(c, GameTag.DEATHRATTLE);
-		case CardIds.KureTheLightBeyond_GDB_442:
-			return (c) => c?.type?.toUpperCase() === CardType[CardType.MINION] && c?.cost === 3;
+		
 		case CardIds.Blasteroid_GDB_303:
 		case CardIds.Supernova_GDB_301:
 			return (c) =>
@@ -292,9 +545,41 @@ const getDynamicFilters = (
 				hasCorrectTribe(c, Race.BEAST) &&
 				canBeDiscoveredByClass(c, options.currentClass) &&
 				(c.cost ?? 0) >= 5;
+
+		// Random X Cost Minion(s)
+		case CardIds.FirstContact_GDB_864:
+		case CardIds.AegisOfLight_EDR_264:
+		case CardIds.FirstDayOfSchool:
+		case CardIds.ShimmerShot_DEEP_003:
+		case CardIds.BuildingBlockGolem_MIS_314:
+			return (c) => c?.type?.toUpperCase() === CardType[CardType.MINION] && c?.cost === 1;
+		
+		case CardIds.RayllaSandSculptor_VAC_424:
+		case CardIds.TwilightInfluence_EDR_463:
+		case CardIds.HarbingerOfTheBlighted_EDR_781:
 		case CardIds.DistressSignal_GDB_883:
+		case CardIds.MazeGuide:
+		case CardIds.MazeGuide_CORE_REV_308:
 		case CardIds.DwarfPlanet_GDB_233:
 			return (c) => c?.type?.toUpperCase() === CardType[CardType.MINION] && c?.cost === 2;
+		
+		case CardIds.KureTheLightBeyond_GDB_442:
+		case CardIds.LinedancePartner_WW_433:
+		case CardIds.HiddenMeaning:
+			return (c) => c?.type?.toUpperCase() === CardType[CardType.MINION] && c?.cost === 3;
+
+		case CardIds.JandiceBarov_SCH_351:
+		case CardIds.WardOfEarth_EDR_060:
+			return (c) => c?.type?.toUpperCase() === CardType[CardType.MINION] && c.cost === 5;
+		
+		case CardIds.FirelandsPortalCore:
+		case CardIds.FirelandsPortal:
+		case CardIds.ChaosCreation_DEEP_031:
+		case CardIds.RitualOfTheNewMoon_RitualOfTheFullMoonToken_EDR_461t:
+			return (c) => c?.type?.toUpperCase() === CardType[CardType.MINION] && c.cost === 6; 
+
+		case CardIds.ScarabKeychain_TOY_006:
+			return (c) => canBeDiscoveredByClass(c, options.currentClass) && c?.cost === 2;
 		case CardIds.ExarchOthaar_GDB_856:
 			return (c) =>
 				c?.type?.toUpperCase() === CardType[CardType.SPELL] &&
@@ -308,8 +593,7 @@ const getDynamicFilters = (
 			return (c) =>
 				c?.type?.toUpperCase() === CardType[CardType.MINION] &&
 				hasCorrectTribe(c, Race.DEMON) &&
-				canBeDiscoveredByClass(c, options.currentClass) &&
-				c?.id !== CardIds.RelentlessWrathguard_GDB_132;
+				canBeDiscoveredByClass(c, options.currentClass);
 		case CardIds.AbductionRay_GDB_123:
 			return (c) => c?.type?.toUpperCase() === CardType[CardType.MINION] && hasCorrectTribe(c, Race.DEMON);
 		case CardIds.Nebula_GDB_479:
@@ -355,6 +639,8 @@ const getDynamicFilters = (
 				hasCorrectTribe(c, Race.DEMON) &&
 				canBeDiscoveredByClass(c, options.currentClass);
 		case CardIds.DraconicStudies:
+		case CardIds.Rheastrasza_WW_824:
+		case CardIds.NetherspiteHistorian:
 		case CardIds.Darkrider_EDR_456:
 			return (c) =>
 				c?.type?.toUpperCase() === CardType[CardType.MINION] &&
@@ -455,8 +741,8 @@ const canBeDiscoveredByClass = (card: ReferenceCard, currentClass: string): bool
 	return card.classes.includes(currentClass.toUpperCase()) || card.classes.includes(CardClass[CardClass.NEUTRAL]);
 };
 
-const fromClass = (card: ReferenceCard, playerClass: CardClass): boolean => {
-	return card?.classes?.includes(CardClass[playerClass]) ?? false;
+const fromClass = (card: ReferenceCard, currentClass: string): boolean => {
+	return card?.classes?.includes(currentClass.toUpperCase()) ?? false;
 };
 
 const fromAnotherClass = (card: ReferenceCard, currentClass: string): boolean => {

--- a/libs/game-state/src/lib/related-cards/dynamic-pools.ts
+++ b/libs/game-state/src/lib/related-cards/dynamic-pools.ts
@@ -48,8 +48,8 @@ export const getDynamicRelatedCardIds = (
 		case CardIds.DreamplannerZephrys_ModestTourToken_WORK_027t1:
 		case CardIds.HopefulDryad_EDR_001:
 			return allCards.getCard(cardId).relatedCardDbfIds?.map((dbfId) => allCards.getCard(dbfId).id) ?? [];
-		case CardIds.FlutterwingGuardian_EDR_800:
 		case CardIds.BitterbloomKnight_EDR_852:
+		case CardIds.FlutterwingGuardian_EDR_800:
 			return {
 				override: true,
 				cards: IMBUED_HERO_POWERS.filter((hp) => allCards.getCard(hp).classes?.includes(options.currentClass)),
@@ -165,20 +165,25 @@ const getDynamicFilters = (
 	},
 ): ((ref: ReferenceCard) => boolean | undefined) | ((ref: ReferenceCard) => boolean)[] | undefined => {
 	switch (cardId) {
+		case CardIds.BlazingInvocation_CORE_GIL_836:
+			return (c) =>
+				hasCorrectType(c, CardType.MINION) &&
+				hasMechanic(c, GameTag.BATTLECRY) &&
+				canBeDiscoveredByClass(c, options.currentClass);
 
 		case CardIds.NecroticMortician:
 		case CardIds.NecroticMortician_CORE_RLK_116:
 			return (c) =>
 				hasCorrectRune(c, 'UNHOLY');
-		case CardIds.Hematurge_RLK_066:
 		case CardIds.Hematurge_CORE_RLK_066:
+		case CardIds.Hematurge_RLK_066:
 			return (c) =>
 				hasCorrectRune(c, 'BLOOD');
 		case CardIds.FrostStrike:
 		case CardIds.FrostStrikeCore:
 			return (c) =>
 				hasCorrectRune(c, 'FROST');
-		
+
 		case CardIds.CorpseFarm_WW_374:
 			return (c) =>
 				hasCorrectType(c, CardType.MINION) &&
@@ -187,7 +192,7 @@ const getDynamicFilters = (
 						8,
 						getPlayerTag(getPlayerOrOpponent(options.deckState, options.gameState), GameTag.CORPSES)
 					)
-				) && 
+				) &&
 				!hasCost(c, '==', 0); // Corpse Farm cannot be played if at 0 Corpses 
 		case CardIds.BlessingOfTheDragon_EmeraldPortalToken_EDR_445pt3:
 			return (c) =>
@@ -202,14 +207,16 @@ const getDynamicFilters = (
 		case CardIds.ShiftySophomore:
 			return (c) =>
 				hasMechanic(c, GameTag.COMBO);
-		case CardIds.BloodsailRecruiter_VAC_430:
-			return (c) =>
-				hasCorrectType(c, CardType.MINION) &&
-				hasCorrectTribe(c, Race.PIRATE);
+
 		case CardIds.ObserverOfMysteries_TOY_520:
 			return (c) =>
 				hasCorrectType(c, CardType.SPELL) &&
 				hasMechanic(c, GameTag.SECRET);
+		case CardIds.Perjury_CORE_MAW_018:
+			return (c) =>
+				hasCorrectType(c, CardType.SPELL) &&
+				hasMechanic(c, GameTag.SECRET) &&
+				fromAnotherClass(c, options.currentClass);
 		case CardIds.DelayedProduct_MIS_305:
 			return (c) =>
 				hasCorrectType(c, CardType.MINION) &&
@@ -219,8 +226,8 @@ const getDynamicFilters = (
 			return (c) =>
 				hasCorrectType(c, CardType.MINION) &&
 				hasCost(c, '==', 6);
-		case CardIds.SpotTheDifference_TOY_374:
 		case CardIds.IncredibleValue_TOY_046:
+		case CardIds.SpotTheDifference_TOY_374:
 			return (c) =>
 				hasCorrectType(c, CardType.MINION) &&
 				hasCost(c, '==', 4) &&
@@ -248,10 +255,6 @@ const getDynamicFilters = (
 			return (c) =>
 				hasCorrectType(c, CardType.SPELL) &&
 				hasCost(c, '==', options.deckState.chaoticTendrilsPlayedThisMatch + 1);
-		case CardIds.RunesOfDarkness_YOG_511:
-			return (c) =>
-				hasCorrectType(c, CardType.WEAPON) &&
-				canBeDiscoveredByClass(c, options.currentClass);
 		case CardIds.OnceUponATime_TOY_506:
 			return (c) =>
 				hasCorrectType(c, CardType.MINION) &&
@@ -274,9 +277,8 @@ const getDynamicFilters = (
 			return (c) =>
 				hasCorrectType(c, CardType.MINION) &&
 				(hasCost(c, '==', 6) || hasCost(c, '==', 3));
-
-		case CardIds.GorillabotA3Core:
 		case CardIds.GorillabotA3:
+		case CardIds.GorillabotA3Core:
 			return (c) =>
 				hasCorrectType(c, CardType.MINION) &&
 				hasCorrectTribe(c, Race.MECH);
@@ -315,19 +317,113 @@ const getDynamicFilters = (
 				hasCorrectType(c, CardType.SPELL) &&
 				hasMechanic(c, GameTag.SECRET) &&
 				c.classes?.includes(CardClass[CardClass.MAGE]);
-		case CardIds.WishingWell_WW_415:
 		case CardIds.SneedsOldShredder_CORE_GVG_114:
+		case CardIds.WishingWell_WW_415:
 			return (c) =>
 				hasCorrectType(c, CardType.MINION) &&
 				hasCorrectRarity(c, CardRarity.LEGENDARY);
+		case CardIds.WyrmrestPurifier:
+			return (c) =>
+				canBeDiscoveredByClass(c, options.currentClass);
+		// Random Class Cards from a specific class
+		case CardIds.LightforgedCrusader:
+			return (c) =>
+				c.classes?.includes(CardClass[CardClass.PALADIN]);
+		case CardIds.AnnounceDarkness_VAC_941:
+			return (c) =>
+				c.classes?.includes(CardClass[CardClass.WARLOCK]);
+		case CardIds.EnvoyOfTheGlade_EDR_873:
+			return (c) =>
+				c.classes?.includes(CardClass[CardClass.DRUID]);
+
+		case CardIds.WorldPillarFragmentToken_DEEP_999t3:
 		case CardIds.MaruutStonebinder_DEEP_037:
 			return (c) =>
 				hasCorrectType(c, CardType.MINION) &&
-				hasCorrectTribe(c, Race.ELEMENTAL);
+				hasCorrectTribe(c, Race.ELEMENTAL) &&
+				canBeDiscoveredByClass(c, options.currentClass);
+		// Random Legendaries
+		case CardIds.ArchVillainRafaam_CORE_DAL_422:
+		case CardIds.ChalkArtist_TOY_388:
+		case CardIds.GoldenKobold:
+		case CardIds.MarinTheManager_GoldenKoboldToken_VAC_702t4:
+		case CardIds.TreasureSeekerElise_GoldenMonkeyToken:
+		case CardIds.Transmogrifier:
+			return (c) => hasCorrectType(c, CardType.MINION) && hasCorrectRarity(c, CardRarity.LEGENDARY);
+
+		// Random X Tribe	
+		// Random Elementals
+		case CardIds.MenacingNimbusCore:
+			return (c) => hasCorrectType(c, CardType.MINION) && hasCorrectTribe(c, Race.ELEMENTAL);
+
+		// Random Naga
+		case CardIds.HuddleUp_WORK_012:
+			return (c) => hasCorrectType(c, CardType.MINION) && hasCorrectTribe(c, Race.NAGA);
+
+		// Random Murlocs
+		case CardIds.GnawingGreenfin_EDR_999:
+		case CardIds.Howdyfin_WW_333:
+		case CardIds.UnderlightAnglingRod:
+			return (c) => hasCorrectType(c, CardType.MINION) && hasCorrectTribe(c, Race.MURLOC);
+
+		// Random Beasts
+		case CardIds.JeweledMacaw:
+		case CardIds.Webspinner_CORE_FP1_011:
 		case CardIds.WildernessPack_MIS_104:
 			return (c) =>
 				hasCorrectType(c, CardType.MINION) &&
 				hasCorrectTribe(c, Race.BEAST);
+
+		case CardIds.Kiljaeden_GDB_145:
+			return (c) =>
+				hasCorrectType(c, CardType.MINION) &&
+				hasCorrectTribe(c, Race.DEMON);
+
+		// Discover an X Tribe
+		// Discover a Dragon
+		case CardIds.AzureExplorer:
+		case CardIds.BronzeExplorer:
+		case CardIds.BronzeExplorerCore:
+		case CardIds.DraconicLackey:
+		case CardIds.EmeraldExplorer_DRG_313:
+		case CardIds.PrimordialExplorer:
+		case CardIds.Darkrider_EDR_456:
+		case CardIds.DraconicStudies:
+		case CardIds.NetherspiteHistorian:
+		case CardIds.Rheastrasza_WW_824:
+			return (c) =>
+				hasCorrectType(c, CardType.MINION) &&
+				hasCorrectTribe(c, Race.DRAGON) &&
+				canBeDiscoveredByClass(c, options.currentClass);
+		
+		// Discover a Beast
+		// TODO: Update Raptor Herald if it changes after EDR
+		case CardIds.RaptorHerald_CORE_EDR_004:
+			return (c) =>
+				hasCorrectType(c, CardType.MINION) &&
+				hasCorrectTribe(c, Race.BEAST) &&
+				canBeDiscoveredByClass(c, options.currentClass);
+		
+		// Discover a Pirate
+		case CardIds.BloodsailRecruiter_VAC_430:
+			return (c) =>
+				hasCorrectType(c, CardType.MINION) &&
+				hasCorrectTribe(c, Race.PIRATE) &&
+				canBeDiscoveredByClass(c, options.currentClass);
+
+		// Discover a Demon
+		case CardIds.WindowShopper_WindowShopperToken_TOY_652t:
+		case CardIds.DemonicStudies:
+		case CardIds.DemonicStudies_CORE_SCH_158:
+		case CardIds.ShadowflameStalker_FIR_924:
+		case CardIds.RelentlessWrathguard_GDB_132:
+		case CardIds.DemonicDynamics:
+			return (c) =>
+				hasCorrectType(c, CardType.MINION) &&
+				hasCorrectTribe(c, Race.DEMON) &&
+				canBeDiscoveredByClass(c, options.currentClass);
+		
+		case CardIds.ExoticMountseller:
 		case CardIds.TeachersPet:
 			return (c) =>
 				hasCorrectType(c, CardType.MINION) &&
@@ -361,16 +457,16 @@ const getDynamicFilters = (
 					hasCorrectSpellSchool(c, SpellSchool.FROST) ||
 					hasCorrectSpellSchool(c, SpellSchool.NATURE)
 				);
-		case CardIds.Peon_BAR_022:
-		case CardIds.OnyxMagescribe:
-			return (c) =>
-				hasCorrectType(c, CardType.SPELL) &&
-				c?.classes?.includes(options.currentClass.toUpperCase());
+
 		case CardIds.Jackpot:
 			return (c) =>
 				hasCorrectType(c, CardType.SPELL) &&
 				hasCost(c, '>=', 5) &&
 				fromAnotherClass(c, options.currentClass);
+		case CardIds.TheFiresOfZinAzshari:
+			return (c) =>
+				hasCorrectType(c, CardType.MINION) &&
+				hasCost(c, '>=', 5);
 		case CardIds.SunkenSweeper:
 			return (c) =>
 				hasCorrectType(c, CardType.MINION) &&
@@ -385,10 +481,7 @@ const getDynamicFilters = (
 				hasCorrectType(c, CardType.MINION) &&
 				(hasCorrectTribe(c, Race.PIRATE) ||
 					c.mechanics?.includes(GameTag[GameTag.STEALTH]));
-		case CardIds.PlaguedProtodrake:
-			return (c) =>
-				hasCorrectType(c, CardType.MINION) &&
-				hasCost(c, '==', 7);
+
 		case CardIds.ExarchHataaru_GDB_136:
 			return (c) =>
 				hasCorrectType(c, CardType.SPELL) &&
@@ -402,14 +495,59 @@ const getDynamicFilters = (
 			return (c) =>
 				hasCorrectType(c, CardType.SPELL) &&
 				hasCost(c, '<=', 3);
+
+		// Discover a Spell Effects (or spell from class effects such as Peon / Magescribe)
+		case CardIds.Qonzu_EDR_517:
+		case CardIds.RunedOrb_BAR_541:
+		case CardIds.Spellcoiler:
+		case CardIds.VulperaScoundrel:
+		case CardIds.VenomousScorpid:
+		case CardIds.StewardOfScrolls_SCH_245:
+		case CardIds.PrimordialGlyph_CORE_UNG_941:
+		case CardIds.Kalecgos_CORE_DAL_609:
+		case CardIds.Marshspawn_CORE_BT_115:
+		case CardIds.EtherealLackey:
+		case CardIds.Peon_BAR_022:
+		case CardIds.OnyxMagescribe:
+		case CardIds.SuspiciousAlchemist:
+		case CardIds.AmphibiousElixir_WW_080:
+		case CardIds.Astrobiologist_GDB_874:
+			return (c) =>
+				hasCorrectType(c, CardType.SPELL) &&
+				canBeDiscoveredByClass(c, options.currentClass);
+
+		// Discover a Weapon Effects (or spell from class effects such as Peon / Magescribe)
+		case CardIds.RunesOfDarkness_YOG_511:
+		case CardIds.SuspiciousPirate:
+			return (c) =>
+				hasCorrectType(c, CardType.WEAPON) &&
+				canBeDiscoveredByClass(c, options.currentClass);
+
+		// Discover a Legendary Minion Effects
+		case CardIds.TreacherousTormentor_EDR_102:
+		case CardIds.SuspiciousUsher_CORE_REV_002:
+		case CardIds.Paparazzi:
+			return (c) =>
+				hasCorrectType(c, CardType.MINION) &&
+				hasCorrectRarity(c, CardRarity.LEGENDARY) &&
+				canBeDiscoveredByClass(c, options.currentClass);
+
+		// Random Mage Spell Effects
+		case CardIds.BabblingBookCore:
+		case CardIds.BabblingBookcase_CORE_EDR_001:
 		case CardIds.WandThief_SCH_350:
 			return (c) =>
 				hasCorrectType(c, CardType.SPELL) &&
 				c.classes?.includes(CardClass[CardClass.MAGE])
-		case CardIds.SunsetVolley_WW_427:
-			return (c) =>
-				hasCorrectType(c, CardType.MINION) &&
-				hasCost(c, '==', 10);
+
+		// Discover an X cost card
+		case CardIds.DarkPeddler_CORE_WON_096:
+		case CardIds.SuspiciousPeddler:
+			return (c) => canBeDiscoveredByClass(c, options.currentClass) && hasCost(c, '==', 1);
+
+		case CardIds.ScarabKeychain_TOY_006:
+			return (c) => canBeDiscoveredByClass(c, options.currentClass) && hasCost(c, '==', 2);
+
 		case CardIds.TrainingSession_NX2_029:
 		case CardIds.HikingTrail_VAC_517:
 		case CardIds.StonehillDefender_Core_UNG_072:
@@ -446,8 +584,6 @@ const getDynamicFilters = (
 				canBeDiscoveredByClass(c, options.currentClass) &&
 				hasCorrectSpellSchool(c, SpellSchool.FEL) &&
 				hasCorrectType(c, CardType.SPELL);
-		case CardIds.ShadowflameStalker_FIR_924:
-			return (c) => hasCorrectTribe(c, Race.DEMON) && canBeDiscoveredByClass(c, options.currentClass);
 		case CardIds.EmberscarredWhelp_FIR_927:
 			return (c) => canBeDiscoveredByClass(c, options.currentClass) && hasCost(c, '==', 5);
 		case CardIds.Cremate_FIR_900:
@@ -467,9 +603,6 @@ const getDynamicFilters = (
 			return (c) =>
 				hasCorrectType(c, CardType.SPELL) &&
 				(c.classes?.includes(CardClass[CardClass.MAGE]) || c.classes?.includes(CardClass[CardClass.DRUID]))
-		case CardIds.BabblingBookcase_CORE_EDR_001:
-			return (c) =>
-				hasCorrectType(c, CardType.SPELL) && c.classes?.includes(CardClass[CardClass.MAGE]);
 		case CardIds.GiftOfFire_EDR_872A:
 			return (c) =>
 				hasCorrectType(c, CardType.SPELL) &&
@@ -517,14 +650,7 @@ const getDynamicFilters = (
 		case CardIds.Ysondre_EDR_465:
 		case CardIds.SelenicDrake_EDR_462:
 			return (c) => hasCorrectType(c, CardType.MINION) && hasCorrectTribe(c, Race.DRAGON);
-		case CardIds.Howdyfin_WW_333:
-		case CardIds.GnawingGreenfin_EDR_999:
-			return (c) => hasCorrectType(c, CardType.MINION) && hasCorrectTribe(c, Race.MURLOC);
-		case CardIds.TreacherousTormentor_EDR_102:
-			return (c) =>
-				hasCorrectType(c, CardType.MINION) &&
-				hasCorrectRarity(c, CardRarity.LEGENDARY) &&
-				canBeDiscoveredByClass(c, options.currentClass);
+
 		case CardIds.FlintFirearm_WW_379:
 			return (c) => c?.mechanics?.includes(GameTag[GameTag.QUICKDRAW]);
 		case CardIds.StickUp_WW_411:
@@ -587,53 +713,60 @@ const getDynamicFilters = (
 				hasCost(c, '>=', 5);
 
 		// Random X Cost Minion(s)
-		case CardIds.FirstContact_GDB_864:
 		case CardIds.AegisOfLight_EDR_264:
-		case CardIds.FirstDayOfSchool:
-		case CardIds.ShimmerShot_DEEP_003:
 		case CardIds.BuildingBlockGolem_MIS_314:
+		case CardIds.FirstContact_GDB_864:
+		case CardIds.FirstDayOfSchool:
+		case CardIds.MaelstromPortal_CORE_KAR_073:
+		case CardIds.ShriekingShroom:
+		case CardIds.ShimmerShot_DEEP_003:
 			return (c) => hasCorrectType(c, CardType.MINION) && hasCost(c, '==', 1);
-
-		case CardIds.RayllaSandSculptor_VAC_424:
-		case CardIds.TwilightInfluence_EDR_463:
-		case CardIds.HarbingerOfTheBlighted_EDR_781:
 		case CardIds.DistressSignal_GDB_883:
+		case CardIds.DwarfPlanet_GDB_233:
+		case CardIds.FacelessLackey:
+		case CardIds.HarbingerOfTheBlighted_EDR_781:
 		case CardIds.MazeGuide:
 		case CardIds.MazeGuide_CORE_REV_308:
-		case CardIds.DwarfPlanet_GDB_233:
+		case CardIds.RayllaSandSculptor_VAC_424:
+		case CardIds.SilvermoonPortal_CORE_KAR_077:
+		case CardIds.TwilightInfluence_EDR_463:
 			return (c) => hasCorrectType(c, CardType.MINION) && hasCost(c, '==', 2);
-
+		case CardIds.HiddenMeaning:
 		case CardIds.KureTheLightBeyond_GDB_442:
 		case CardIds.LinedancePartner_WW_433:
-		case CardIds.HiddenMeaning:
+		case CardIds.SerpentshrinePortal_BT_100:
 			return (c) => hasCorrectType(c, CardType.MINION) && hasCost(c, '==', 3);
-
+		case CardIds.IronforgePortal:
+		case CardIds.IronforgePortal_WON_337:
+			return (c) => hasCorrectType(c, CardType.MINION) && hasCost(c, '==', 4);
 		case CardIds.JandiceBarov_SCH_351:
 		case CardIds.WardOfEarth_EDR_060:
 			return (c) => hasCorrectType(c, CardType.MINION) && hasCost(c, '==', 5);
-
-		case CardIds.FirelandsPortalCore:
-		case CardIds.FirelandsPortal:
+		case CardIds.BigBadArchmage:
 		case CardIds.ChaosCreation_DEEP_031:
+		case CardIds.FirelandsPortal:
+		case CardIds.FirelandsPortalCore:
+		case CardIds.MoongladePortal_KAR_075:
 		case CardIds.RitualOfTheNewMoon_RitualOfTheFullMoonToken_EDR_461t:
 			return (c) => hasCorrectType(c, CardType.MINION) && hasCost(c, '==', 6);
 
-		case CardIds.ScarabKeychain_TOY_006:
-			return (c) => canBeDiscoveredByClass(c, options.currentClass) && hasCost(c, '==', 2);
+		case CardIds.PlaguedProtodrake:
+			return (c) => hasCorrectType(c, CardType.MINION) && hasCost(c, '==', 7);
+
+		case CardIds.SunsetVolley_WW_427:
+			return (c) =>
+				hasCorrectType(c, CardType.MINION) &&
+				hasCost(c, '==', 10);
+
 		case CardIds.ExarchOthaar_GDB_856:
 			return (c) =>
 				hasCorrectType(c, CardType.SPELL) &&
 				hasCorrectSpellSchool(c, SpellSchool.ARCANE);
-		case CardIds.HuddleUp_WORK_012:
-			return (c) => hasCorrectType(c, CardType.MINION) && hasCorrectTribe(c, Race.NAGA);
+
 		case CardIds.HologramOperator_GDB_723:
 		case CardIds.OrbitalSatellite_GDB_462:
 			return (c) => hasCorrectType(c, CardType.MINION) && hasCorrectTribe(c, Race.DRAENEI);
-		case CardIds.RelentlessWrathguard_GDB_132:
-			return (c) =>
-				hasCorrectType(c, CardType.MINION) &&
-				hasCorrectTribe(c, Race.DEMON) &&
-				canBeDiscoveredByClass(c, options.currentClass);
+		
 		case CardIds.AbductionRay_GDB_123:
 			return (c) => hasCorrectType(c, CardType.MINION) && hasCorrectTribe(c, Race.DEMON);
 		case CardIds.Nebula_GDB_479:
@@ -671,21 +804,7 @@ const getDynamicFilters = (
 		case CardIds.NatureStudies_SCH_333:
 			return (c) =>
 				hasCorrectType(c, CardType.SPELL) && canBeDiscoveredByClass(c, options.currentClass);
-		case CardIds.DemonicStudies:
-		case CardIds.DemonicStudies_CORE_SCH_158:
-		case CardIds.DemonicDynamics:
-			return (c) =>
-				hasCorrectType(c, CardType.MINION) &&
-				hasCorrectTribe(c, Race.DEMON) &&
-				canBeDiscoveredByClass(c, options.currentClass);
-		case CardIds.DraconicStudies:
-		case CardIds.Rheastrasza_WW_824:
-		case CardIds.NetherspiteHistorian:
-		case CardIds.Darkrider_EDR_456:
-			return (c) =>
-				hasCorrectType(c, CardType.MINION) &&
-				hasCorrectTribe(c, Race.DRAGON) &&
-				canBeDiscoveredByClass(c, options.currentClass);
+		
 		case CardIds.GalacticCrusader_GDB_862:
 			return (c) =>
 				hasCorrectType(c, CardType.SPELL) &&

--- a/libs/game-state/src/lib/related-cards/dynamic-pools.ts
+++ b/libs/game-state/src/lib/related-cards/dynamic-pools.ts
@@ -191,7 +191,7 @@ const getDynamicFilters = (
 				hasCost(c, '==',
 					Math.min(
 						8,
-						getPlayerTag(getPlayerOrOpponent(options.deckState, options.gameState), GameTag.CORPSES)
+						getPlayerTag(getPlayerOrOpponentFromFullGameState(options.deckState, options.gameState), GameTag.CORPSES)
 					)
 				) &&
 				!hasCost(c, '==', 0); // Corpse Farm cannot be played if at 0 Corpses 
@@ -202,7 +202,7 @@ const getDynamicFilters = (
 				hasCost(c, '==',
 					Math.min(
 						10,
-						getPlayerTag(getPlayerOrOpponent(options.deckState, options.gameState), GameTag.IMBUES_THIS_GAME)
+						getPlayerTag(getPlayerOrOpponentFromFullGameState(options.deckState, options.gameState), GameTag.IMBUES_THIS_GAME)
 					)
 				);
 		case CardIds.ShiftySophomore:
@@ -940,7 +940,7 @@ const fromAnotherClass = (card: ReferenceCard, currentClass: string): boolean =>
 
 
 
-const getPlayerOrOpponent = (deckState: DeckState, gameState: GameState): PlayerGameState | undefined => {
+const getPlayerOrOpponentFromFullGameState = (deckState: DeckState, gameState: GameState): PlayerGameState | undefined => {
 	return deckState.isOpponent
 		? gameState.fullGameState?.Opponent
 		: gameState.fullGameState?.Player;

--- a/libs/game-state/src/lib/related-cards/dynamic-pools.ts
+++ b/libs/game-state/src/lib/related-cards/dynamic-pools.ts
@@ -7,6 +7,7 @@ import {
 	CardRarity,
 	CardType,
 	CREWMATES,
+	DkruneTypes,
 	GameFormat,
 	GameTag,
 	GameType,
@@ -174,15 +175,15 @@ const getDynamicFilters = (
 		case CardIds.NecroticMortician:
 		case CardIds.NecroticMortician_CORE_RLK_116:
 			return (c) =>
-				hasCorrectRune(c, 'UNHOLY');
+				hasCorrectRune(c, DkruneTypes.UNHOLYRUNE);
 		case CardIds.Hematurge_CORE_RLK_066:
 		case CardIds.Hematurge_RLK_066:
 			return (c) =>
-				hasCorrectRune(c, 'BLOOD');
+				hasCorrectRune(c, DkruneTypes.BLOODRUNE);
 		case CardIds.FrostStrike:
 		case CardIds.FrostStrikeCore:
 			return (c) =>
-				hasCorrectRune(c, 'FROST');
+				hasCorrectRune(c, DkruneTypes.FROSTRUNE);
 
 		case CardIds.CorpseFarm_WW_374:
 			return (c) =>
@@ -894,13 +895,13 @@ const getPlayerTag = (playerGameState: PlayerGameState | undefined, gameTag: Gam
 	return playerGameState?.PlayerEntity?.tags?.find((t) => t.Name === gameTag)?.Value ?? defaultValue
 }
 
-const hasCorrectRune = (card: ReferenceCard, runeType: string): boolean => {
+const hasCorrectRune = (card: ReferenceCard, runeType: DkruneTypes): boolean => {
 	switch (runeType) {
-		case 'BLOOD':
+		case DkruneTypes.BLOODRUNE:
 			return (card?.additionalCosts?.BLOODRUNE ?? 0) > 0;
-		case 'UNHOLY':
+		case DkruneTypes.UNHOLYRUNE:
 			return (card?.additionalCosts?.UNHOLYRUNE ?? 0) > 0;
-		case 'FROST':
+		case DkruneTypes.FROSTRUNE:
 			return (card?.additionalCosts?.FROSTRUNE ?? 0) > 0;
 		default:
 			return false;

--- a/libs/game-state/src/lib/related-cards/dynamic-pools.ts
+++ b/libs/game-state/src/lib/related-cards/dynamic-pools.ts
@@ -741,10 +741,6 @@ const canBeDiscoveredByClass = (card: ReferenceCard, currentClass: string): bool
 	return card.classes.includes(currentClass.toUpperCase()) || card.classes.includes(CardClass[CardClass.NEUTRAL]);
 };
 
-const fromClass = (card: ReferenceCard, currentClass: string): boolean => {
-	return card?.classes?.includes(currentClass.toUpperCase()) ?? false;
-};
-
 const fromAnotherClass = (card: ReferenceCard, currentClass: string): boolean => {
 	return (
 		!card?.classes?.includes(CardClass[CardClass.NEUTRAL]) && !card?.classes?.includes(currentClass?.toUpperCase())

--- a/libs/game-state/src/lib/related-cards/related-cards.ts
+++ b/libs/game-state/src/lib/related-cards/related-cards.ts
@@ -1,13 +1,10 @@
 /* eslint-disable no-case-declarations */
 import { CardClass, CardIds } from '@firestone-hs/reference-data';
 import { CardsFacadeService } from '@firestone/shared/framework/core';
-import {
-	DeckState,
-	GameState,
-	getDynamicRelatedCardIds,
-	hasOverride,
-	Metadata,
-} from '@firestone/game-state';
+import { DeckState } from '../models/deck-state';
+import { GameState } from '../models/game-state';
+import { Metadata } from '../models/metadata';
+import { getDynamicRelatedCardIds, hasOverride } from './dynamic-pools';
 
 export const buildContextRelatedCardIds = (
 	cardId: string,

--- a/libs/game-state/src/lib/related-cards/related-cards.ts
+++ b/libs/game-state/src/lib/related-cards/related-cards.ts
@@ -1,9 +1,13 @@
 /* eslint-disable no-case-declarations */
 import { CardClass, CardIds } from '@firestone-hs/reference-data';
 import { CardsFacadeService } from '@firestone/shared/framework/core';
-import { DeckState } from '../models/deck-state';
-import { Metadata } from '../models/metadata';
-import { getDynamicRelatedCardIds, hasOverride } from './dynamic-pools';
+import {
+	DeckState,
+	GameState,
+	getDynamicRelatedCardIds,
+	hasOverride,
+	Metadata,
+} from '@firestone/game-state';
 
 export const buildContextRelatedCardIds = (
 	cardId: string,
@@ -11,6 +15,7 @@ export const buildContextRelatedCardIds = (
 	deckState: DeckState,
 	metaData: Metadata,
 	allCards: CardsFacadeService,
+	gameState: GameState
 ): readonly string[] => {
 	switch (cardId) {
 		case CardIds.ETCBandManager_ETC_080:
@@ -25,6 +30,7 @@ export const buildContextRelatedCardIds = (
 				gameType: metaData.gameType,
 				currentClass: !deckState?.hero?.classes?.[0] ? '' : CardClass[deckState?.hero?.classes?.[0]],
 				deckState: deckState,
+				gameState: gameState
 			});
 			if (hasOverride(dynamicCards)) {
 				return (dynamicCards as { cards: readonly string[] }).cards;

--- a/libs/legacy/feature-shell/src/lib/js/components/overlays/opponenthand/opponent-card-info-id.component.ts
+++ b/libs/legacy/feature-shell/src/lib/js/components/overlays/opponenthand/opponent-card-info-id.component.ts
@@ -4,6 +4,7 @@ import { CardClass, CardIds } from '@firestone-hs/reference-data';
 import {
 	DeckCard,
 	DeckState,
+	GameState,
 	getDynamicRelatedCardIds,
 	getPossibleForgedCards,
 	GuessedInfo,
@@ -69,7 +70,7 @@ export class OpponentCardInfoIdComponent extends AbstractSubscriptionComponent i
 	@Input() displayGuess: boolean;
 	@Input() displayBuff: boolean;
 
-	@Input() set context(value: { deck: DeckState; metadata: Metadata; currentTurn: number | 'mulligan' }) {
+	@Input() set context(value: { deck: DeckState; gameState: GameState; metadata: Metadata; currentTurn: number | 'mulligan' }) {
 		this.context$$.next(value);
 	}
 	@Input() set card(value: DeckCard) {
@@ -78,6 +79,7 @@ export class OpponentCardInfoIdComponent extends AbstractSubscriptionComponent i
 
 	private context$$ = new BehaviorSubject<{
 		deck: DeckState;
+		gameState: GameState;
 		metadata: Metadata;
 		currentTurn: number | 'mulligan';
 	} | null>(null);
@@ -174,6 +176,7 @@ export class OpponentCardInfoIdComponent extends AbstractSubscriptionComponent i
 				gameType: metadata.gameType,
 				currentClass: !context?.hero?.classes?.[0] ? '' : CardClass[context?.hero?.classes?.[0]],
 				deckState: context,
+				gameState: this.context$$.value?.gameState,
 			});
 			const pool = hasOverride(dynamicPool) ? (dynamicPool as { cards: readonly string[] }).cards : dynamicPool;
 			if (!!pool?.length) {

--- a/libs/legacy/feature-shell/src/lib/js/components/overlays/opponenthand/opponent-card-info.component.ts
+++ b/libs/legacy/feature-shell/src/lib/js/components/overlays/opponenthand/opponent-card-info.component.ts
@@ -1,5 +1,10 @@
 import { AfterContentInit, ChangeDetectorRef, Component, ElementRef, Input, Renderer2, ViewRef } from '@angular/core';
-import { DeckCard, DeckState, Metadata } from '@firestone/game-state';
+import { 
+	DeckCard, 
+	DeckState, 
+	GameState, 
+	Metadata 
+} from '@firestone/game-state';
 import { PreferencesService } from '@firestone/shared/common/service';
 import { combineLatest } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
@@ -32,7 +37,7 @@ export class OpponentCardInfoComponent extends AbstractSubscriptionStoreComponen
 	// the play area are cropped
 	@Input() leftVwOffset: number;
 	@Input() topVwOffset: number;
-	@Input() context: { deck: DeckState; metadata: Metadata; currentTurn: number | 'mulligan' };
+	@Input() context: { deck: DeckState; gameState: GameState, metadata: Metadata; currentTurn: number | 'mulligan' };
 	@Input() card: DeckCard;
 
 	constructor(

--- a/libs/legacy/feature-shell/src/lib/js/components/overlays/opponenthand/opponent-card-infos.component.ts
+++ b/libs/legacy/feature-shell/src/lib/js/components/overlays/opponenthand/opponent-card-infos.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input } from '@angular/core';
-import { DeckCard, DeckState, Metadata } from '@firestone/game-state';
+import { DeckCard, DeckState, Metadata, GameState } from '@firestone/game-state';
 import { OverwolfService } from '@firestone/shared/framework/core';
 import { Map } from 'immutable';
 
@@ -26,7 +26,7 @@ export class OpponentCardInfosComponent {
 	@Input() displayGuess: boolean;
 	@Input() displayBuff: boolean;
 	@Input() displayTurnNumber: boolean;
-	@Input() context: { deck: DeckState; metadata: Metadata; currentTurn: number | 'mulligan' };
+	@Input() context: { deck: DeckState; gameState: GameState; metadata: Metadata; currentTurn: number | 'mulligan' };
 	@Input() cards: readonly DeckCard[];
 
 	private handAdjustment: Map<number, Adjustment> = this.buildHandAdjustment();

--- a/libs/legacy/feature-shell/src/lib/js/components/overlays/opponenthand/opponent-hand-overlay.component.ts
+++ b/libs/legacy/feature-shell/src/lib/js/components/overlays/opponenthand/opponent-hand-overlay.component.ts
@@ -7,7 +7,7 @@ import {
 	ViewRef,
 } from '@angular/core';
 import { GameTag } from '@firestone-hs/reference-data';
-import { DeckCard, DeckState, GameStateFacadeService, Metadata } from '@firestone/game-state';
+import { DeckCard, DeckState, GameState, GameStateFacadeService, Metadata } from '@firestone/game-state';
 import { PreferencesService } from '@firestone/shared/common/service';
 import { AbstractSubscriptionComponent } from '@firestone/shared/framework/common';
 import { OverwolfService, waitForReady } from '@firestone/shared/framework/core';
@@ -34,7 +34,7 @@ export class OpponentHandOverlayComponent extends AbstractSubscriptionComponent 
 	displayTurnNumber$: Observable<boolean>;
 	displayGuess$: Observable<boolean>;
 	displayBuff$: Observable<boolean>;
-	context$: Observable<{ deck: DeckState; metadata: Metadata; currentTurn: number | 'mulligan' }>;
+	context$: Observable<{ deck: DeckState; gameState: GameState; metadata: Metadata; currentTurn: number | 'mulligan' }>;
 
 	constructor(
 		protected readonly cdr: ChangeDetectorRef,
@@ -61,6 +61,7 @@ export class OpponentHandOverlayComponent extends AbstractSubscriptionComponent 
 			auditTime(500),
 			this.mapData((gameState) => ({
 				deck: gameState?.opponentDeck,
+				gameState: gameState,
 				metadata: gameState?.metadata,
 				currentTurn: gameState?.currentTurn,
 			})),

--- a/libs/legacy/feature-shell/src/lib/js/services/decktracker/card-highlight/cards-highlight-common.service.ts
+++ b/libs/legacy/feature-shell/src/lib/js/services/decktracker/card-highlight/cards-highlight-common.service.ts
@@ -130,7 +130,7 @@ export abstract class CardsHighlightCommonService extends AbstractSubscriptionCo
 		const deckCards = deck.getAllCardsInDeckWithoutOptions();
 		const card =
 			deckCards.find((c) => !!entityId && c.entityId === entityId) ?? deckCards.find((c) => c.cardId === cardId);
-		const relatedCardIds = buildContextRelatedCardIds(cardId, card?.relatedCardIds, deck, metaData, this.allCards);
+		const relatedCardIds = buildContextRelatedCardIds(cardId, card?.relatedCardIds, deck, metaData, this.allCards, this.gameState);
 		return relatedCardIds?.length ? relatedCardIds : [];
 	}
 

--- a/libs/legacy/feature-shell/src/lib/js/services/decktracker/event-parser/custom-effects-parser.ts
+++ b/libs/legacy/feature-shell/src/lib/js/services/decktracker/event-parser/custom-effects-parser.ts
@@ -91,6 +91,7 @@ export class CustomEffectsParser implements EventParser {
 					? CardClass[currentState.playerDeck.hero.classes[0]]
 					: null,
 				deckState: deck,
+				gameState: currentState
 			},
 		);
 		const pool = hasOverride(dynamicPool) ? (dynamicPool as { cards: readonly string[] }).cards : dynamicPool;


### PR DESCRIPTION
Original Discord Thread: https://discord.com/channels/187101197767933952/1372915546479136788

TBD: Screenshots for Validation(s)

I've also added in a way to implement GameState which can be helpful for some cards (Emerald Portals, Corpse Farm, etc)
And I've added in some utility functions to simplify the logic / code written in the dynamic-pools.ts file.

I made updates and added dynamic card pools to the following checked items:
- [x] First Day of School  
- [x] Partner Assignment  
- [x] Fool's Gold  
- [x] Shifty Sophomore  
- [x] Rite of Atrocity  
- [x] Farm Hand  
- [x] Ward of Earth  
- [x] Twilight Influence  
- [x] Harbinger of the Blighted  
- [x] Maze Guide  
- [x] Ritual of the New Moon  
- [x] Ritual of the Full Moon  
- [x] Jandice Barov  
- [x] Selenic Drake  
- [x] Ysondre  
- [x] Dragon Tales  
- [x] Runed Orb  
- [x] Spellcoiler  
- [x] Q'onzu  
- [x] Vulpera Scoundrel  
- [x] Venomous Scorpid  
- [x] Steward of Scrolls  
- [x] Peon  
- [x] Onyx Magescribe  
- [x] Inferno Herald  
- [x] Aegis of Light  
- [x] Emerald Portals (re: Paladin's Imbue counter)  
- [x] Smoke Bomb  
- [x] Cremate  
- [x] Emberscarred Whelp  
- [x] Avant-Gardening  
- [x] Shadowflame Stalker  
- [x] Shadowflame Suffusion  
- [x] Darkride  
- [x] Gnawing Greenfin  
- [x] Howdyfin  
- [x] Treacherous Tormentor  
- [x] Malorne The Waywatcher  * (clunky, need to fix)*
- [x] Fyrakk the Blazing  
- [x] Netherspite Historian  
- [x] Rheastrazsa  
- [x] Gorillabot A-3  
- [x] Stonehill Defender  
- [x] Sneed's Old Shredder  
- [x] Mismatched Fossils  
- [x] Corpse Farm (if possible)  
- [x] Shimmer Shot (if possible)  
- [ ] Spurfang (if possible)  
- [x] Obsidian Revenant  
- [x] Stormcoil Mothership  
- [x] Oasis Outlaws  
- [x] Cactus Construct  
- [x] Saddle Up!  
- [x] Sunset Volley  
- [x] Firelands Portal  
- [x] Chaos Creation  
- [x] Reliquary Researcher  
- [x] Wishing Well  
- [x] Eroded Sediment  
- [x] Linedance Partner  
- [x] Maruut Stonebinder  
- [x] School Teacher  (Kinda)
- [x] Azsharan Scroll  
- [x] Sunken Scroll  
- [x] Jackpot!  
- [x] Submerged Spacerock  
- [x] Sunken Sweeper  
- [ ] Hedra the Heretic (if possible)  
- [x] Pack Kodo  
- [x] Savory Deviate Delight  
- [x] Plagued Protodrake  
- [ ] Steeldancer (if possible)  
- [x] In Formation!  
- [x] Athletic Studies  
- [x] Demonic Studies  
- [x] Illidari Studies  
- [x] Draconic Studies  
- [x] Nature Studies  
- [x] Primordial Studies  
- [x] Carrion Studies  
- [x] Instructor Fireheart  
- [x] Trick Totem  
- [x] Wand Thief  
- [x] Teacher's Pet 
- [x] Hiking Trail
- [x] Standardized Pack
- [x] Training Session
- [x] Exarch Hataaru
- [x] Everything Must Go!
- [x] Raylla
- [x] Hidden Meaning
- [x] Once Upon A Time
- [x] Chaotic Tendril (this one's the most fun of all)
- [x] Wilderness Pack
- [x] Blind Box
- [x] Window Shopper
- [x] Hidden Objects
- [x] Spot the Difference
- [x] Incredible Value
- [x] Scarab Keychain
- [x] Observer of Mysteries
- [x] Travel Agent
- [x] Bloodsail Recruiter
- [x] Building Block Golem
- [x] swashburglar / undercity huckster / shaku, the collector / academic espionage  
- [x] frost strike  
- [x] hematurge  
- [x] necrotic mortician  
- [x] webspinner / jeweled macaw  
- [x] babbling book / bookcase  
- [x] primordial glyph / kalecgos / marshspawn / ethereal lackey  
- [x] silvermoon portal  
- [x] ironforge portal  
- [x] maelstrom portal  
- [x] underlight angling rod  
- [x] blazing invocation  
- [x] menacing nimbus  
- [x] suspicious alchemist / amphibious elixir  
- [x] suspicious pirate  
- [x] suspicious usher  
- [x] dark / suspicious peddler  
- [x] perjury  
- [x] i know a guy  
- [x] bronze / azure / emerald / primordial explorer / draconic lackey  
- [x] faceless lackey  
- [x] kil'jaeden  
- [ ] anachronos' victims  
- [x] the fires of zin-azshari  
- [x] world pillar fragment / maruut stonebinder  
- [x] envoy of the glade  
- [x] transmogrifier / golden kobold / golden monkey / arch-villain rafaam  
- [x] wyrmrest purifier  
- [x] lightforged crusader  
- [x] announce darkness  
- [x] exotic mountseller  
- [x] big bad archmage  
- [ ] primordial protector  
- [x] shrieking shroom  
- [x] huddle up  
- [x] once upon a time  


- Botface (which I believe i implemented properly, but doesnt look like it's properly working (tagging on the backend, perhaps for Minis?)
