### PR TITLE
Firestone issue 1471

### DIFF
--- a/libs/game-state/src/lib/related-cards/dynamic-pools.ts
+++ b/libs/game-state/src/lib/related-cards/dynamic-pools.ts
@@ -713,9 +713,14 @@ const getDynamicFilters = (
 		case CardIds.TimeLostProtodrake:
 			return (c) => hasCorrectType(c, CardType.MINION) && hasCorrectTribe(c, Race.DRAGON);
 		case CardIds.PastConflux_TIME_436:
+			return (c) => hasCorrectType(c, CardType.MINION) && hasCorrectTribe(c, Race.DRAGON) && hasCost(c, '>=', 5);
 		case CardIds.PastConflux_PresentConfluxToken_TIME_436t1:
 		case CardIds.PastConflux_FutureConfluxToken_TIME_436t2:
-			return (c) => hasCorrectType(c, CardType.MINION) && hasCorrectTribe(c, Race.DRAGON) && hasCost(c, '>=', 5);
+			return (c) =>
+				hasCorrectType(c, CardType.MINION) &&
+				hasCorrectTribe(c, Race.DRAGON) &&
+				hasCost(c, '>=', 5) &&
+				canBeDiscoveredByClass(c, options.currentClass);
 
 		// Random Undead
 		case CardIds.ForgottenMillennium_TIME_615:


### PR DESCRIPTION
Fix Present Conflux and Future Conflux to exclude dragons from other classes.

Present Conflux and Future Conflux are discover effects, so they should only offer Priest or neutral dragons. Past Conflux is a random effect and correctly remains without class restriction.

---
<a href="https://cursor.com/background-agent?bcId=bc-618851a6-d79e-4ebf-86b3-c134fdc64580"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-618851a6-d79e-4ebf-86b3-c134fdc64580"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Limit Present/Future Conflux to discover only current-class/neutral Dragons costing 5+, while Past Conflux remains a random 5+ Dragon pool.
> 
> - **Dynamic related card pools (`libs/game-state/src/lib/related-cards/dynamic-pools.ts`)**:
>   - **Present/Future Conflux**: Added `canBeDiscoveredByClass(options.currentClass)` to restrict discovered Dragons (cost 5+) to current-class or neutral.
>   - **Past Conflux**: Ensures pool targets Dragons with cost `>= 5` (random, no class restriction).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e24c36b633779cdc1795df5d18b9dd8175577a70. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->