### PR TITLE
Github context response

### DIFF
--- a/libs/legacy/feature-shell/src/lib/js/services/decktracker/card-highlight/card-id-selectors.ts
+++ b/libs/legacy/feature-shell/src/lib/js/services/decktracker/card-highlight/card-id-selectors.ts
@@ -1884,6 +1884,8 @@ export const cardIdSelector = (
 				and(side(inputSide), inGraveyard, minion),
 				and(side(inputSide), or(inHand, inDeck), minion),
 			);
+		case CardIds.IdolOfYshaarj:
+			return and(side(inputSide), inDeck, minion);
 		case CardIds.IdolsOfEluneTavernBrawl:
 			return and(side(inputSide), or(inDeck, inHand), spell);
 		case CardIds.IngeniousArtificer_GDB_135:

--- a/libs/legacy/feature-shell/src/lib/js/services/decktracker/card-highlight/tools/flat-condition-mappings.json
+++ b/libs/legacy/feature-shell/src/lib/js/services/decktracker/card-highlight/tools/flat-condition-mappings.json
@@ -155,6 +155,7 @@
     "SicklyGrimewalker_YOG_512",
     "SkeletalSidekickCore_RLK_958",
     "SoulburnerVaria_YOG_520",
+    "StormTheGates_TLC_EVENT_400",
     "TwistedTether",
     "UndyingAllies",
     "UnlivingChampion",
@@ -166,6 +167,7 @@
     "AzsharanSaber_SunkenSaberToken",
     "BeastmasterLeoroxx",
     "BigDreams",
+    "BlessingOfTheWolf_EDR_850p",
     "BunnyStomper_WW_435",
     "ButchTavernBrawl",
     "CallPet_GVG_017",
@@ -173,6 +175,7 @@
     "CastleKennels_REV_790",
     "CattleRustler_WW_351",
     "CowerInFear_TLC_823",
+    "Dinomancy_DinomancyToken",
     "Dinositter_TLC_822",
     "ExoticHoundmaster_EDR_226",
     "FaithfulCompanions",
@@ -223,6 +226,7 @@
     "ShandoWildclaw_RileTheHerd",
     "ShandoWildclaw_Transfiguration",
     "StarvingTavernBrawl",
+    "StormTheGates_TLC_EVENT_400",
     "StormpikeBattleRam",
     "StranglethornHeart",
     "SupremeDinomancy_TLC_828",
@@ -556,6 +560,7 @@
     "CarnivorousCubicle_WORK_042",
     "CatrinaMuerte",
     "CatrinaMuerteCore",
+    "ChalkArtist_TOY_388",
     "CharredChameleon_FIR_908",
     "ChemicalSpill_TOY_602",
     "ChorusRiff",
@@ -621,6 +626,7 @@
     "HabeasCorpses",
     "Hadronox_CORE_ICC_835",
     "Hadronox_ICC_835",
+    "HagathaTheWitch_BewitchHeroic",
     "HagathasEmbrace",
     "HagathasEmbraceTavernBrawl",
     "HarmonicMetal",
@@ -635,6 +641,7 @@
     "HopeOfQuelthalas",
     "HoundsOfFury_TIME_443",
     "HourglassAttendant_TIME_100",
+    "IdolOfYshaarj",
     "ImpKingRafaam_ImpKingRafaamToken",
     "ImpKingRafaam_REV_789",
     "ImpKingRafaam_REV_835",
@@ -1077,8 +1084,8 @@
     "EaglehornBowLegacy",
     "EaglehornBowVanilla",
     "GhastlyGravedigger",
-    "GlacialMysteries",
-    "GlacialMysteriesCore",
+    "GlacialMysteries_CORE_ICC_086",
+    "GlacialMysteries_ICC_086",
     "KabalCrystalRunner",
     "KabalCrystalRunner_WON_308",
     "MadScientist",
@@ -1102,6 +1109,7 @@
     "AzeriteGiant_WW_025",
     "Blazecaller",
     "BlazingAccretion_GDB_302",
+    "BonfireElemental",
     "BralmaSearstone_TLC_228",
     "CloudSerpent_TLC_888",
     "DangBlastedElemental_WW_397",
@@ -1223,6 +1231,14 @@
     "ParrotSanctuary_VAC_409",
     "Snapdragon",
     "Turbulus_WORK_013"
+  ],
+  "IMBUE": [
+    "AwakenTheFlame",
+    "AwakenTheFlame_THD_029hp",
+    "DreamboundDisciple_EDR_847",
+    "MalorneTheWaywatcher_EDR_888",
+    "PetalPicker_FIR_921",
+    "ResplendentDreamweaver_EDR_860"
   ],
   "MURLOC": [
     "AzsharanScavenger_SunkenScavengerToken",
@@ -1397,6 +1413,7 @@
     "BrilliantMacaw",
     "ChronoLordDeios_TIME_064",
     "CorruptTheWaters",
+    "CorruptTheWaters_HeartOfVirnaal",
     "FieldContact",
     "MurmuringElemental",
     "RallyTheTroopsTavernBrawl",
@@ -1506,6 +1523,7 @@
     "ScrapbookingStudent_VAC_529",
     "SeasideGiant_VAC_439",
     "SpineCrawler_SC_023",
+    "WelcomeHome_TIME_EVENT_997",
     "WorkshopJanitor_TOY_891",
     "Xb931Housekeeper_VAC_956"
   ],
@@ -1614,9 +1632,12 @@
   ],
   "FROM_ANOTHER_CLASS": [
     "Concierge_VAC_463",
+    "ContrabandStash",
     "DoubleAgent",
     "SeaShill_VAC_332",
     "SnatchAndGrab_VAC_700",
+    "TessGreymaneCore",
+    "TessGreymane_GIL_598",
     "TreasureHunterEudora_VAC_464",
     "VelarokWindblade_WW_364",
     "Vendetta"
@@ -1711,12 +1732,6 @@
   "COST_LESS_4 + HAS_MECHANIC_DEATHRATTLE + MINION": [
     "DreadRaptor_TLC_432",
     "Razorboar"
-  ],
-  "IMBUE": [
-    "DreamboundDisciple_EDR_847",
-    "MalorneTheWaywatcher_EDR_888",
-    "PetalPicker_FIR_921",
-    "ResplendentDreamweaver_EDR_860"
   ],
   "MINION + MURLOC": [
     "DrocomurchanicasTavernBrawlToken",

--- a/libs/legacy/feature-shell/src/lib/js/services/decktracker/card-highlight/tools/missing-cards-analysis.json
+++ b/libs/legacy/feature-shell/src/lib/js/services/decktracker/card-highlight/tools/missing-cards-analysis.json
@@ -1,12 +1,13 @@
 {
-  "totalOriginal": 1682,
-  "totalProcessed": 1567,
-  "totalMissing": 111,
+  "totalOriginal": 1694,
+  "totalProcessed": 1581,
+  "totalMissing": 109,
   "missingCards": [
     "AbyssalDepths",
     "AstralVigilant_GDB_461",
     "BaritoneImp",
     "BonecrusherTavernBrawlToken",
+    "Broxigar_AxeOfCenariusToken_TIME_020t1",
     "CallToAdventure",
     "CagematchCustodian",
     "CaptureColdtoothMine",
@@ -18,7 +19,6 @@
     "CloningDevice",
     "ColdFeet",
     "ConnivingConman_VAC_333",
-    "ContrabandStash",
     "CrazedConductor",
     "Crescendo",
     "CthunsChosen",
@@ -103,8 +103,6 @@
     "SwinetuskShank",
     "SymphonyOfSins_MovementOfPrideToken",
     "TaelanFordringCore",
-    "TessGreymane_GIL_598",
-    "TessGreymaneCore",
     "The8HandsFromBeyond_GDB_477",
     "TheFinsBeyondTime_TIME_706",
     "TimelordNozdormu_TIME_063",
@@ -115,5 +113,5 @@
     "VelenLeaderOfTheExiled_GDB_131",
     "WildSpirits"
   ],
-  "analysisDate": "2025-12-11T07:18:47.153Z"
+  "analysisDate": "2025-12-23T09:11:05.162Z"
 }

--- a/libs/legacy/feature-shell/src/lib/js/services/decktracker/card-highlight/tools/reverse-general-selectors.ts
+++ b/libs/legacy/feature-shell/src/lib/js/services/decktracker/card-highlight/tools/reverse-general-selectors.ts
@@ -449,7 +449,7 @@ export const reverseGeneralSelector = (
 		);
 	}
 
-	// HAS_MECHANIC_BATTLECRY (12 cards)
+	// HAS_MECHANIC_BATTLECRY (13 cards)
 	if (refCard.mechanics?.includes('BATTLECRY')) {
 		matchingCardIds.push(
 			CardIds.BattleTotem_LOOTA_846,
@@ -458,6 +458,7 @@ export const reverseGeneralSelector = (
 			CardIds.BrilliantMacaw,
 			CardIds.ChronoLordDeios_TIME_064,
 			CardIds.CorruptTheWaters,
+			CardIds.CorruptTheWaters_HeartOfVirnaal,
 			CardIds.FieldContact,
 			CardIds.MurmuringElemental,
 			CardIds.RallyTheTroopsTavernBrawl,
@@ -584,7 +585,7 @@ export const reverseGeneralSelector = (
 		);
 	}
 
-	// LOCATION (9 cards)
+	// LOCATION (10 cards)
 	if (refCard.type?.toUpperCase() === 'LOCATION') {
 		matchingCardIds.push(
 			CardIds.BusyPeon_WORK_041,
@@ -594,6 +595,7 @@ export const reverseGeneralSelector = (
 			CardIds.ScrapbookingStudent_VAC_529,
 			CardIds.SeasideGiant_VAC_439,
 			CardIds.SpineCrawler_SC_023,
+			CardIds.WelcomeHome_TIME_EVENT_997,
 			CardIds.WorkshopJanitor_TOY_891,
 			CardIds.Xb931Housekeeper_VAC_956
 		);

--- a/libs/legacy/feature-shell/src/lib/js/services/decktracker/card-highlight/tools/reverse-minion-selectors.ts
+++ b/libs/legacy/feature-shell/src/lib/js/services/decktracker/card-highlight/tools/reverse-minion-selectors.ts
@@ -417,7 +417,7 @@ export const reverseMinionSelector = (
 		);
 	}
 
-	// BEAST (77 cards)
+	// BEAST (80 cards)
 	if (refCard.races?.map(r => r.toUpperCase()).includes('BEAST')) {
 		matchingCardIds.push(
 			CardIds.AddledGrizzly,
@@ -425,6 +425,7 @@ export const reverseMinionSelector = (
 			CardIds.AzsharanSaber_SunkenSaberToken,
 			CardIds.BeastmasterLeoroxx,
 			CardIds.BigDreams,
+			CardIds.BlessingOfTheWolf_EDR_850p,
 			CardIds.BunnyStomper_WW_435,
 			CardIds.ButchTavernBrawl,
 			CardIds.CallPet_GVG_017,
@@ -432,6 +433,7 @@ export const reverseMinionSelector = (
 			CardIds.CastleKennels_REV_790,
 			CardIds.CattleRustler_WW_351,
 			CardIds.CowerInFear_TLC_823,
+			CardIds.Dinomancy_DinomancyToken,
 			CardIds.Dinositter_TLC_822,
 			CardIds.ExoticHoundmaster_EDR_226,
 			CardIds.FaithfulCompanions,
@@ -482,6 +484,7 @@ export const reverseMinionSelector = (
 			CardIds.ShandoWildclaw_RileTheHerd,
 			CardIds.ShandoWildclaw_Transfiguration,
 			CardIds.StarvingTavernBrawl,
+			CardIds.StormTheGates_TLC_EVENT_400,
 			CardIds.StormpikeBattleRam,
 			CardIds.StranglethornHeart,
 			CardIds.SupremeDinomancy_TLC_828,
@@ -621,7 +624,7 @@ export const reverseMinionSelector = (
 		);
 	}
 
-	// ELEMENTAL (46 cards)
+	// ELEMENTAL (47 cards)
 	if (refCard.races?.map(r => r.toUpperCase()).includes('ELEMENTAL')) {
 		matchingCardIds.push(
 			CardIds.AnimatedAvalanche,
@@ -630,6 +633,7 @@ export const reverseMinionSelector = (
 			CardIds.AzeriteGiant_WW_025,
 			CardIds.Blazecaller,
 			CardIds.BlazingAccretion_GDB_302,
+			CardIds.BonfireElemental,
 			CardIds.BralmaSearstone_TLC_228,
 			CardIds.CloudSerpent_TLC_888,
 			CardIds.DangBlastedElemental_WW_397,
@@ -854,7 +858,7 @@ export const reverseMinionSelector = (
 		);
 	}
 
-	// UNDEAD (40 cards)
+	// UNDEAD (41 cards)
 	if (refCard.races?.map(r => r.toUpperCase()).includes('UNDEAD')) {
 		matchingCardIds.push(
 			CardIds.AcolyteOfDeath,
@@ -893,6 +897,7 @@ export const reverseMinionSelector = (
 			CardIds.SicklyGrimewalker_YOG_512,
 			CardIds.SkeletalSidekickCore_RLK_958,
 			CardIds.SoulburnerVaria_YOG_520,
+			CardIds.StormTheGates_TLC_EVENT_400,
 			CardIds.TwistedTether,
 			CardIds.UndyingAllies,
 			CardIds.UnlivingChampion,
@@ -900,7 +905,7 @@ export const reverseMinionSelector = (
 		);
 	}
 
-	// MINION (271 cards)
+	// MINION (274 cards)
 	if (refCard.type?.toUpperCase() === 'MINION') {
 		matchingCardIds.push(
 			CardIds.AcherusVeteran_CORE_ICC_092,
@@ -948,6 +953,7 @@ export const reverseMinionSelector = (
 			CardIds.CarnivorousCubicle_WORK_042,
 			CardIds.CatrinaMuerte,
 			CardIds.CatrinaMuerteCore,
+			CardIds.ChalkArtist_TOY_388,
 			CardIds.CharredChameleon_FIR_908,
 			CardIds.ChemicalSpill_TOY_602,
 			CardIds.ChorusRiff,
@@ -1013,6 +1019,7 @@ export const reverseMinionSelector = (
 			CardIds.HabeasCorpses,
 			CardIds.Hadronox_CORE_ICC_835,
 			CardIds.Hadronox_ICC_835,
+			CardIds.HagathaTheWitch_BewitchHeroic,
 			CardIds.HagathasEmbrace,
 			CardIds.HagathasEmbraceTavernBrawl,
 			CardIds.HarmonicMetal,
@@ -1027,6 +1034,7 @@ export const reverseMinionSelector = (
 			CardIds.HopeOfQuelthalas,
 			CardIds.HoundsOfFury_TIME_443,
 			CardIds.HourglassAttendant_TIME_100,
+			CardIds.IdolOfYshaarj,
 			CardIds.ImpKingRafaam_ImpKingRafaamToken,
 			CardIds.ImpKingRafaam_REV_789,
 			CardIds.ImpKingRafaam_REV_835,

--- a/libs/legacy/feature-shell/src/lib/js/services/decktracker/card-highlight/tools/reverse-spell-selectors.ts
+++ b/libs/legacy/feature-shell/src/lib/js/services/decktracker/card-highlight/tools/reverse-spell-selectors.ts
@@ -8,7 +8,7 @@ import { CardIds } from '@firestone-hs/reference-data';
 import { DeckCard } from '@firestone/game-state';
 import { CardsFacadeService, HighlightSide } from '@firestone/shared/framework/core';
 import { Selector } from '../cards-highlight-common.service';
-import { and, cardIs, inDeck, inHand, or, side } from '../selectors';
+import { and, or, side, inDeck, inHand, cardIs } from '../selectors';
 
 export const reverseSpellSelector = (
 	cardId: string,
@@ -22,12 +22,10 @@ export const reverseSpellSelector = (
 	const matchingCardIds: CardIds[] = [];
 
 	// COST_MORE_0 + SHADOW + SPELL (1 cards)
-	if (
-		refCard.cost > 0 &&
-		refCard.spellSchool?.toUpperCase() === 'SHADOW' &&
-		refCard.type?.toUpperCase() === 'SPELL'
-	) {
-		matchingCardIds.push(CardIds.TamsinRoame_BAR_918);
+	if (refCard.cost > 0 && refCard.spellSchool?.toUpperCase() === 'SHADOW' && refCard.type?.toUpperCase() === 'SPELL') {
+		matchingCardIds.push(
+			CardIds.TamsinRoame_BAR_918
+		);
 	}
 
 	// ARCANE + SPELL (8 cards)
@@ -40,38 +38,53 @@ export const reverseSpellSelector = (
 			CardIds.Stargazing_WW_425,
 			CardIds.StarlightReactor_GDB_108,
 			CardIds.UnstableMagicTavernBrawl,
-			CardIds.Vexallus,
+			CardIds.Vexallus
 		);
 	}
 
 	// COST_EQUAL_1 + SPELL (2 cards)
 	if (refCard.cost === 1 && refCard.type?.toUpperCase() === 'SPELL') {
-		matchingCardIds.push(CardIds.Gazlowe, CardIds.TrinketTracker);
+		matchingCardIds.push(
+			CardIds.Gazlowe,
+			CardIds.TrinketTracker
+		);
 	}
 
 	// COST_EQUAL_2 + SPELL (2 cards)
 	if (refCard.cost === 2 && refCard.type?.toUpperCase() === 'SPELL') {
-		matchingCardIds.push(CardIds.BarakKodobane_BAR_551, CardIds.BarakKodobane_CORE_BAR_551);
+		matchingCardIds.push(
+			CardIds.BarakKodobane_BAR_551,
+			CardIds.BarakKodobane_CORE_BAR_551
+		);
 	}
 
 	// COST_EQUAL_8 + SPELL (1 cards)
 	if (refCard.cost === 8 && refCard.type?.toUpperCase() === 'SPELL') {
-		matchingCardIds.push(CardIds.ArcaneBrilliance);
+		matchingCardIds.push(
+			CardIds.ArcaneBrilliance
+		);
 	}
 
 	// COST_LESS_3 + SPELL (2 cards)
 	if (refCard.cost < 3 && refCard.type?.toUpperCase() === 'SPELL') {
-		matchingCardIds.push(CardIds.SunsapperLynessa_VAC_507, CardIds.VioletTreasuregill_TLC_438);
+		matchingCardIds.push(
+			CardIds.SunsapperLynessa_VAC_507,
+			CardIds.VioletTreasuregill_TLC_438
+		);
 	}
 
 	// COST_LESS_4 + SPELL (1 cards)
 	if (refCard.cost < 4 && refCard.type?.toUpperCase() === 'SPELL') {
-		matchingCardIds.push(CardIds.StonehearthVindicator);
+		matchingCardIds.push(
+			CardIds.StonehearthVindicator
+		);
 	}
 
 	// COST_MORE_1 + SPELL (1 cards)
 	if (refCard.cost > 1 && refCard.type?.toUpperCase() === 'SPELL') {
-		matchingCardIds.push(CardIds.PlaguebringerTavernBrawl);
+		matchingCardIds.push(
+			CardIds.PlaguebringerTavernBrawl
+		);
 	}
 
 	// COST_MORE_4 + SPELL (7 cards)
@@ -83,13 +96,15 @@ export const reverseSpellSelector = (
 			CardIds.Groundskeeper,
 			CardIds.HagathaTheFabled_TOY_504,
 			CardIds.SunreaverWarmage,
-			CardIds.WeaverOfTheCycle_EDR_472,
+			CardIds.WeaverOfTheCycle_EDR_472
 		);
 	}
 
 	// COST_MORE_5 + SPELL (1 cards)
 	if (refCard.cost > 5 && refCard.type?.toUpperCase() === 'SPELL') {
-		matchingCardIds.push(CardIds.GreySageParrot);
+		matchingCardIds.push(
+			CardIds.GreySageParrot
+		);
 	}
 
 	// FEL + SPELL (10 cards)
@@ -104,7 +119,7 @@ export const reverseSpellSelector = (
 			CardIds.ImpCredibleTrousersTavernBrawl,
 			CardIds.PopgarThePutrid_WW_091,
 			CardIds.Scorchreaver_FIR_952,
-			CardIds.WitherTheWeakTavernBrawl,
+			CardIds.WitherTheWeakTavernBrawl
 		);
 	}
 
@@ -122,7 +137,7 @@ export const reverseSpellSelector = (
 			CardIds.ScorchingWinds_FIR_910,
 			CardIds.SunfuryChampion,
 			CardIds.Thoribelore,
-			CardIds.VolcanicThrasher_TLC_223,
+			CardIds.VolcanicThrasher_TLC_223
 		);
 	}
 
@@ -136,7 +151,7 @@ export const reverseSpellSelector = (
 			CardIds.LadyDeathwhisper_RLK_713,
 			CardIds.RambunctiousStuffy_TOY_821,
 			CardIds.Rimetongue,
-			CardIds.WatercolorArtist_TOY_376,
+			CardIds.WatercolorArtist_TOY_376
 		);
 	}
 
@@ -167,7 +182,7 @@ export const reverseSpellSelector = (
 			CardIds.SecretkeeperVanilla,
 			CardIds.SparkjoyCheat,
 			CardIds.StarstrungBow,
-			CardIds.SwordOfTheFallen,
+			CardIds.SwordOfTheFallen
 		);
 	}
 
@@ -188,7 +203,7 @@ export const reverseSpellSelector = (
 			CardIds.ShimmeringSunfish,
 			CardIds.StarlightGroove,
 			CardIds.TheGardensGrace,
-			CardIds.VeteranWarmedic,
+			CardIds.VeteranWarmedic
 		);
 	}
 
@@ -204,7 +219,7 @@ export const reverseSpellSelector = (
 			CardIds.SpreadingSaplingsTavernBrawl,
 			CardIds.ToadOfTheWilds,
 			CardIds.TopiorTheShrubbagazzor,
-			CardIds.WidowbloomSeedsman,
+			CardIds.WidowbloomSeedsman
 		);
 	}
 
@@ -221,7 +236,7 @@ export const reverseSpellSelector = (
 			CardIds.ShadowclothNeedle,
 			CardIds.SketchArtist_TOY_916,
 			CardIds.StaffOfPainTavernBrawl,
-			CardIds.TwilightDeceptor,
+			CardIds.TwilightDeceptor
 		);
 	}
 
@@ -233,13 +248,17 @@ export const reverseSpellSelector = (
 			CardIds.ArcaniteCrystalTavernBrawl,
 			CardIds.AzureQueenSindragosa_TIME_852,
 			CardIds.LadyNazjar_TID_709,
-			CardIds.SorcerersGambit,
+			CardIds.SorcerersGambit
 		);
 	}
 
 	// FEL (3 cards)
 	if (refCard.spellSchool?.toUpperCase() === 'FEL') {
-		matchingCardIds.push(CardIds.CorruptedFelstoneTavernBrawl, CardIds.FelfireInTheHole, CardIds.JaceDarkweaver);
+		matchingCardIds.push(
+			CardIds.CorruptedFelstoneTavernBrawl,
+			CardIds.FelfireInTheHole,
+			CardIds.JaceDarkweaver
+		);
 	}
 
 	// FIRE (7 cards)
@@ -251,7 +270,7 @@ export const reverseSpellSelector = (
 			CardIds.Saruun_GDB_304,
 			CardIds.SorcerersGambit,
 			CardIds.SteamGuardian,
-			CardIds.WrathspineEnchanter,
+			CardIds.WrathspineEnchanter
 		);
 	}
 
@@ -266,7 +285,7 @@ export const reverseSpellSelector = (
 			CardIds.OverseerFrigidara_LEG_RLK_224,
 			CardIds.RadianceOfAzshara_TSC_635,
 			CardIds.SorcerersGambit,
-			CardIds.WrathspineEnchanter,
+			CardIds.WrathspineEnchanter
 		);
 	}
 
@@ -284,8 +303,8 @@ export const reverseSpellSelector = (
 			CardIds.EaglehornBowLegacy,
 			CardIds.EaglehornBowVanilla,
 			CardIds.GhastlyGravedigger,
-			CardIds.GlacialMysteries_ICC_086,
 			CardIds.GlacialMysteries_CORE_ICC_086,
+			CardIds.GlacialMysteries_ICC_086,
 			CardIds.KabalCrystalRunner,
 			CardIds.KabalCrystalRunner_WON_308,
 			CardIds.MadScientist,
@@ -297,7 +316,7 @@ export const reverseSpellSelector = (
 			CardIds.ScuttlebuttGhoul_CORE_REV_900,
 			CardIds.SecretStudiesTavernBrawl,
 			CardIds.SpringTheTrap,
-			CardIds.Zuljin_WarriorsOfAmani_THD_010p,
+			CardIds.Zuljin_WarriorsOfAmani_THD_010p
 		);
 	}
 
@@ -311,7 +330,7 @@ export const reverseSpellSelector = (
 			CardIds.LightmawNetherdrake,
 			CardIds.ReachEquilibrium_TLC_817,
 			CardIds.SpiritGuide,
-			CardIds.SpiritGuide_CORE_AV_328,
+			CardIds.SpiritGuide_CORE_AV_328
 		);
 	}
 
@@ -324,7 +343,7 @@ export const reverseSpellSelector = (
 			CardIds.Overheat_FIR_906,
 			CardIds.PrimalDungeoneer,
 			CardIds.RadianceOfAzshara_TSC_635,
-			CardIds.WrathspineEnchanter,
+			CardIds.WrathspineEnchanter
 		);
 	}
 
@@ -338,7 +357,7 @@ export const reverseSpellSelector = (
 			CardIds.LightmawNetherdrake,
 			CardIds.ReachEquilibrium_TLC_817,
 			CardIds.SpiritGuide,
-			CardIds.SpiritGuide_CORE_AV_328,
+			CardIds.SpiritGuide_CORE_AV_328
 		);
 	}
 
@@ -556,7 +575,7 @@ export const reverseSpellSelector = (
 			CardIds.YoggSaronHopesEnd_OG_134,
 			CardIds.YoggSaronMasterOfFate,
 			CardIds.YsielWindsinger,
-			CardIds.Zuljin,
+			CardIds.Zuljin
 		);
 	}
 


### PR DESCRIPTION
Add Idol of Y'Shaarj card highlighting for minions in the deck to fix #1479.

---
<a href="https://cursor.com/background-agent?bcId=bc-6ac72622-5448-48f5-8691-e4e7928f69b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6ac72622-5448-48f5-8691-e4e7928f69b8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds missing highlight logic and refreshes mappings for consistency across selectors and tools.
> 
> - New rule in `card-id-selectors.ts` for `IdolOfYshaarj` to highlight `minion` cards in the deck
> - Updates `flat-condition-mappings.json`: adds entries across `UNDEAD`, `BEAST`, `MINION`, `ELEMENTAL`, `LOCATION`, `FROM_ANOTHER_CLASS`, `HAS_MECHANIC_BATTLECRY`; introduces `IMBUE`; corrects `GlacialMysteries` IDs
> - Syncs reverse selectors (`reverse-general-selectors.ts`, `reverse-minion-selectors.ts`, `reverse-spell-selectors.ts`) to include these cards and adjust counts
> - Refreshes `missing-cards-analysis.json` totals and timestamp
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b6b9c24435d00a9b9f93c2905c94fc1c9d50fd1b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->