### PR TITLE
Github message review

### DIFF
--- a/libs/game-state/src/lib/services/cards/toysnatching-geist.ts
+++ b/libs/game-state/src/lib/services/cards/toysnatching-geist.ts
@@ -8,11 +8,12 @@ import { filterCards } from './utils';
 export const ToysnatchingGeist: GeneratingCard = {
 	cardIds: [CardIds.ToysnatchingGeist_MIS_006],
 	publicCreator: true,
+	hasSequenceInfo: true,
 	guessCardId: (input: GuessCardIdInput): string | null => {
 		if (input.createdIndex === 1) {
 			return CardIds.ToysnatchingGeist_ToysnatchingGeistToken_MIS_006t;
 		}
-		return input.cardId;
+		return null;
 	},
 	guessInfo: (input: GuessInfoInput): GuessedInfo | null => {
 		const currentClass = input.deckState.hero?.classes?.[0] ? CardClass[input.deckState.hero?.classes?.[0]] : '';


### PR DESCRIPTION
Correct Toysnatching Geist oracle to properly handle sequence info and unknown discovered cards.

The card was missing `hasSequenceInfo: true` and incorrectly returned `input.cardId` for the discovered minion (index 0) instead of `null`. This prevented the UI from correctly showing the discovered minion as unknown and distinguishing it from the 0-cost token, matching the pattern of cards like Window Shopper.

---
<a href="https://cursor.com/background-agent?bcId=bc-f91f8691-c8f6-4a2f-9661-a9b3403a172b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f91f8691-c8f6-4a2f-9661-a9b3403a172b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **fix: Toysnatching Geist oracle**
> 
> - Add `hasSequenceInfo: true` to `ToysnatchingGeist`
> - Update `guessCardId`: keep token mapping for `createdIndex === 1`, return `null` otherwise (no longer echo `input.cardId`)
> 
> These changes let the UI treat the discovered minion as unknown and distinct from the 0-cost token.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5ef5db92acd346619d09686b7cf3d1bc7704f6c1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->