### PR TITLE
Github message review

### DIFF
--- a/libs/game-state/src/lib/related-cards/dynamic-pools.ts
+++ b/libs/game-state/src/lib/related-cards/dynamic-pools.ts
@@ -1064,6 +1064,7 @@ const getDynamicFilters = (
 		case CardIds.ToysnatchingGeist_ToysnatchingGeistToken_MIS_006t:
 		case CardIds.RiteOfAtrocity_EDR_811:
 		case CardIds.Paleomancy_TLC_434:
+		case CardIds.PulsingPumpkins_TOY_829hp:
 			return (c) => hasCorrectTribe(c, Race.UNDEAD) && canBeDiscoveredByClass(c, options.currentClass);
 		case CardIds.SweetenedSnowflurry_TOY_307:
 		case CardIds.SweetenedSnowflurry_SweetenedSnowflurryToken_TOY_307t:


### PR DESCRIPTION
Add Pulsing Pumpkins to dynamic pools to correctly show discoverable Undead minions.

---
<a href="https://cursor.com/background-agent?bcId=bc-400552e3-6fb5-4b82-a2aa-60a15d7b6bd7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-400552e3-6fb5-4b82-a2aa-60a15d7b6bd7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures correct Discover results for Pulsing Pumpkins.
> 
> - Update `dynamic-pools.ts` to map `PulsingPumpkins_TOY_829hp` to `Undead` minion discovery filtered by `canBeDiscoveredByClass`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 797f1968e38a75253919a518390264661dddb43e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->