### PR TITLE
In-game tracker flavor text

### DIFF
--- a/libs/legacy/feature-shell/src/lib/css/component/overlays/flavor-text/flavor-text-widget-wrapper.component.scss
+++ b/libs/legacy/feature-shell/src/lib/css/component/overlays/flavor-text/flavor-text-widget-wrapper.component.scss
@@ -1,0 +1,23 @@
+:host {
+	position: absolute;
+	bottom: 20px;
+	right: 20px;
+	z-index: 9999;
+	pointer-events: none;
+}
+
+.widget {
+	pointer-events: auto;
+	animation: fadeIn 0.2s ease-in-out;
+}
+
+@keyframes fadeIn {
+	from {
+		opacity: 0;
+		transform: translateY(10px);
+	}
+	to {
+		opacity: 1;
+		transform: translateY(0);
+	}
+}

--- a/libs/legacy/feature-shell/src/lib/css/component/overlays/flavor-text/flavor-text.component.scss
+++ b/libs/legacy/feature-shell/src/lib/css/component/overlays/flavor-text/flavor-text.component.scss
@@ -1,0 +1,39 @@
+@use '../../../global/fonts' as *;
+
+:host {
+	display: block;
+}
+
+.flavor-text-container {
+	display: flex;
+	flex-direction: column;
+	background: linear-gradient(135deg, rgba(30, 20, 15, 0.95), rgba(45, 30, 20, 0.95));
+	border: 1px solid #8b6914;
+	border-radius: 8px;
+	width: 320px;
+	max-width: 320px;
+	padding: 12px 15px;
+	box-shadow:
+		0 4px 12px rgba(0, 0, 0, 0.8),
+		inset 0 1px 0 rgba(255, 215, 0, 0.1);
+
+	.card-name {
+		font-family: 'Belwe', serif;
+		font-size: 16px;
+		font-weight: bold;
+		color: #ffb948;
+		margin-bottom: 8px;
+		text-shadow: 1px 1px 2px rgba(0, 0, 0, 0.8);
+		border-bottom: 1px solid rgba(139, 105, 20, 0.5);
+		padding-bottom: 8px;
+	}
+
+	.flavor-text {
+		font-family: 'Open Sans', sans-serif;
+		font-size: 13px;
+		font-style: italic;
+		color: #d9c3ab;
+		line-height: 1.5;
+		text-shadow: 1px 1px 1px rgba(0, 0, 0, 0.5);
+	}
+}

--- a/libs/legacy/feature-shell/src/lib/js/components/overlays/_full-screen-overlays.component.ts
+++ b/libs/legacy/feature-shell/src/lib/js/components/overlays/_full-screen-overlays.component.ts
@@ -148,6 +148,8 @@ import { DebugService } from '../../services/debug.service';
 
 			<lottery-widget-wrapper></lottery-widget-wrapper>
 
+			<flavor-text-widget-wrapper></flavor-text-widget-wrapper>
+
 			<notifications></notifications>
 		</div>
 	`,

--- a/libs/legacy/feature-shell/src/lib/js/components/overlays/flavor-text/flavor-text-widget-wrapper.component.ts
+++ b/libs/legacy/feature-shell/src/lib/js/components/overlays/flavor-text/flavor-text-widget-wrapper.component.ts
@@ -1,0 +1,52 @@
+import { AfterContentInit, ChangeDetectionStrategy, ChangeDetectorRef, Component, ViewRef } from '@angular/core';
+import { SceneMode } from '@firestone-hs/reference-data';
+import { GameStateFacadeService } from '@firestone/game-state';
+import { SceneService } from '@firestone/memory';
+import { FlavorTextService, PreferencesService } from '@firestone/shared/common/service';
+import { AbstractSubscriptionComponent } from '@firestone/shared/framework/common';
+import { waitForReady } from '@firestone/shared/framework/core';
+import { combineLatest, Observable } from 'rxjs';
+
+@Component({
+	standalone: false,
+	selector: 'flavor-text-widget-wrapper',
+	styleUrls: ['../../../../css/component/overlays/flavor-text/flavor-text-widget-wrapper.component.scss'],
+	template: `
+		<flavor-text-widget class="widget" *ngIf="showWidget$ | async"></flavor-text-widget>
+	`,
+	changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class FlavorTextWidgetWrapperComponent extends AbstractSubscriptionComponent implements AfterContentInit {
+	showWidget$: Observable<boolean>;
+
+	constructor(
+		protected readonly cdr: ChangeDetectorRef,
+		private readonly prefs: PreferencesService,
+		private readonly scene: SceneService,
+		private readonly gameState: GameStateFacadeService,
+		private readonly flavorTextService: FlavorTextService,
+	) {
+		super(cdr);
+	}
+
+	async ngAfterContentInit() {
+		await waitForReady(this.scene, this.gameState, this.prefs, this.flavorTextService);
+
+		this.showWidget$ = combineLatest([
+			this.scene.currentScene$$,
+			this.prefs.preferences$$.pipe(this.mapData((prefs) => prefs.overlayShowFlavorTextOnHover)),
+			this.gameState.gameState$$.pipe(
+				this.mapData((state) => state.gameStarted && !state.gameEnded),
+			),
+			this.flavorTextService.flavorText$$,
+		]).pipe(
+			this.mapData(([currentScene, displayFromPrefs, inGame, flavorText]) => {
+				return displayFromPrefs && inGame && currentScene === SceneMode.GAMEPLAY && !!flavorText;
+			}),
+		);
+
+		if (!(this.cdr as ViewRef)?.destroyed) {
+			this.cdr.detectChanges();
+		}
+	}
+}

--- a/libs/legacy/feature-shell/src/lib/js/components/overlays/flavor-text/flavor-text.component.ts
+++ b/libs/legacy/feature-shell/src/lib/js/components/overlays/flavor-text/flavor-text.component.ts
@@ -1,0 +1,38 @@
+import { AfterContentInit, ChangeDetectionStrategy, ChangeDetectorRef, Component, ViewRef } from '@angular/core';
+import { FlavorTextInfo, FlavorTextService } from '@firestone/shared/common/service';
+import { AbstractSubscriptionComponent } from '@firestone/shared/framework/common';
+import { waitForReady } from '@firestone/shared/framework/core';
+import { Observable } from 'rxjs';
+
+@Component({
+	standalone: false,
+	selector: 'flavor-text-widget',
+	styleUrls: ['../../../../css/component/overlays/flavor-text/flavor-text.component.scss'],
+	template: `
+		<div class="flavor-text-container" *ngIf="flavorText$ | async as flavorText">
+			<div class="card-name">{{ flavorText.cardName }}</div>
+			<div class="flavor-text">{{ flavorText.flavorText }}</div>
+		</div>
+	`,
+	changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class FlavorTextComponent extends AbstractSubscriptionComponent implements AfterContentInit {
+	flavorText$: Observable<FlavorTextInfo | null>;
+
+	constructor(
+		protected readonly cdr: ChangeDetectorRef,
+		private readonly flavorTextService: FlavorTextService,
+	) {
+		super(cdr);
+	}
+
+	async ngAfterContentInit() {
+		await waitForReady(this.flavorTextService);
+
+		this.flavorText$ = this.flavorTextService.flavorText$$.pipe(this.mapData((info) => info));
+
+		if (!(this.cdr as ViewRef).destroyed) {
+			this.cdr.detectChanges();
+		}
+	}
+}

--- a/libs/legacy/feature-shell/src/lib/legacy-feature-shell.module.ts
+++ b/libs/legacy/feature-shell/src/lib/legacy-feature-shell.module.ts
@@ -357,6 +357,8 @@ import { OpponentMaxResourcesWidgetWrapperComponent } from '@components/overlays
 import { PlayerMaxResourcesWidgetWrapperComponent } from '@components/overlays/resources/player-max-resources-widget-wrapper.component';
 import { BgsHeroTipsWidgetWrapperComponent } from '@components/overlays/tips/bgs-hero-tips-widget-wrapper.component';
 import { BgsHeroTipsComponent } from '@components/overlays/tips/bgs-hero-tips.component';
+import { FlavorTextComponent } from './js/components/overlays/flavor-text/flavor-text.component';
+import { FlavorTextWidgetWrapperComponent } from './js/components/overlays/flavor-text/flavor-text-widget-wrapper.component';
 import { ChoosingBgsTrinketWidgetWrapperComponent } from '@components/overlays/trinket/choosing-bgs-trinket-widget-wrapper.component';
 import { ChoosingCardBgsTrinketOptionComponent } from '@components/overlays/trinket/choosing-card-bgs-trinket-option.component';
 import { ProfileMatchStatsClassInfoComponent } from '@components/stats/desktop/match-stats/profile-match-stats-class-info.component';
@@ -1236,6 +1238,8 @@ try {
 		BgsBattleSimulationWidgetWrapperComponent,
 		BgsBannedTribesWidgetWrapperComponent,
 		BgsHeroTipsWidgetWrapperComponent,
+		FlavorTextComponent,
+		FlavorTextWidgetWrapperComponent,
 		BgsWindowButtonWidgetWrapperComponent,
 		BgsHeroSelectionWidgetWrapperComponent,
 		BgsLeaderboardWidgetWrapperComponent,

--- a/libs/settings/src/lib/common/models/settings-tree/decktracker/decktracker-settings-global.ts
+++ b/libs/settings/src/lib/common/models/settings-tree/decktracker/decktracker-settings-global.ts
@@ -44,6 +44,12 @@ export const decktrackerGlobalSettings = (context: SettingContext): SettingNode 
 					},
 					{
 						type: 'toggle',
+						field: 'overlayShowFlavorTextOnHover',
+						label: context.i18n.translateString('settings.decktracker.global.show-flavor-text-on-hover'),
+						tooltip: context.i18n.translateString('settings.decktracker.global.show-flavor-text-on-hover-tooltip'),
+					},
+					{
+						type: 'toggle',
 						field: 'overlayShowRelatedCards',
 						label: context.i18n.translateString('settings.collection.general.show-related-cards-label'),
 						tooltip: context.i18n.translateString('settings.collection.general.show-related-cards-tooltip'),

--- a/libs/shared/common/service/src/index.ts
+++ b/libs/shared/common/service/src/index.ts
@@ -8,6 +8,7 @@ export * from './lib/services/bug-report.service';
 export * from './lib/services/disk-cache.service';
 export * from './lib/services/expert-contributors.service';
 export * from './lib/services/feature-flags';
+export * from './lib/services/flavor-text.service';
 export * from './lib/services/free-quotas';
 export * from './lib/services/game-status.service';
 export * from './lib/services/global-error.service';

--- a/libs/shared/common/service/src/lib/models/preferences.ts
+++ b/libs/shared/common/service/src/lib/models/preferences.ts
@@ -280,6 +280,7 @@ export class Preferences implements IPreferences {
 	readonly overlayShowTooltipsOnHover: boolean = true;
 	readonly overlayShowRarityColors: boolean = true;
 	readonly overlayShowRelatedCards: boolean = true;
+	readonly overlayShowFlavorTextOnHover: boolean = false;
 	readonly overlayShowTransformedInto: boolean = true;
 	readonly overlayShowGiftedCardsInSeparateLine: boolean = false;
 	readonly overlayGroupSameCardsTogether: boolean = false;

--- a/libs/shared/common/service/src/lib/services/flavor-text.service.ts
+++ b/libs/shared/common/service/src/lib/services/flavor-text.service.ts
@@ -1,0 +1,37 @@
+import { Injectable } from '@angular/core';
+import { SubscriberAwareBehaviorSubject } from '@firestone/shared/framework/common';
+import { AbstractFacadeService, WindowManagerService } from '@firestone/shared/framework/core';
+
+export interface FlavorTextInfo {
+	cardId: string;
+	cardName: string;
+	flavorText: string;
+}
+
+@Injectable()
+export class FlavorTextService extends AbstractFacadeService<FlavorTextService> {
+	public flavorText$$: SubscriberAwareBehaviorSubject<FlavorTextInfo | null>;
+
+	constructor(protected override readonly windowManager: WindowManagerService) {
+		super(windowManager, 'flavorText', () => !!this.flavorText$$);
+	}
+
+	protected override assignSubjects() {
+		this.flavorText$$ = this.mainInstance.flavorText$$;
+	}
+
+	protected async init() {
+		this.flavorText$$ = new SubscriberAwareBehaviorSubject<FlavorTextInfo | null>(null);
+	}
+
+	public showFlavorText(cardId: string, cardName: string, flavorText: string): void {
+		if (!flavorText?.length) {
+			return;
+		}
+		this.flavorText$$.next({ cardId, cardName, flavorText });
+	}
+
+	public hideFlavorText(): void {
+		this.flavorText$$.next(null);
+	}
+}

--- a/libs/shared/common/service/src/lib/shared-common-service.module.ts
+++ b/libs/shared/common/service/src/lib/shared-common-service.module.ts
@@ -7,6 +7,7 @@ import { AppNavigationService } from './services/app-navigation.service';
 import { BugReportService } from './services/bug-report.service';
 import { DiskCacheService } from './services/disk-cache.service';
 import { ExpertContributorsService } from './services/expert-contributors.service';
+import { FlavorTextService } from './services/flavor-text.service';
 import { GameStatusService } from './services/game-status.service';
 import { LogUtilsService } from './services/log-utils.service';
 import { LogsUploaderService } from './services/logs-uploader.service';
@@ -37,6 +38,7 @@ const components = [AdvancedSettingDirective];
 		LogsUploaderService,
 		BugReportService,
 		ExpertContributorsService,
+		FlavorTextService,
 		DiskCacheService,
 		SubscriptionService,
 		TebexService,


### PR DESCRIPTION
Adds flavor text display to in-game tracker cards on hover, with a user setting to enable/disable it.

---
<a href="https://cursor.com/background-agent?bcId=bc-218fe544-b4fc-4222-9615-2bd5c048d6a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-218fe544-b4fc-4222-9615-2bd5c048d6a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

