### PR TITLE
Protoss minion reverse selectors

### DIFF
--- a/libs/legacy/feature-shell/src/lib/js/services/decktracker/card-highlight/tools/build-reverse-mappings.ts
+++ b/libs/legacy/feature-shell/src/lib/js/services/decktracker/card-highlight/tools/build-reverse-mappings.ts
@@ -816,6 +816,9 @@ function generateMinionFile(flatMappings: { [condition: string]: string[] }): st
 				(condition.includes('UNDEAD') && !condition.includes('HAS_MECHANIC')) ||
 				(condition.includes('NAGA') && !condition.includes('HAS_MECHANIC')) ||
 				(condition.includes('TOTEM') && !condition.includes('HAS_MECHANIC')) ||
+				condition.includes('PROTOSS') ||
+				condition.includes('ZERG') ||
+				condition.includes('TERRAN') ||
 				condition.includes('ATTACK') ||
 				condition.includes('NOT_TRIBELESS');
 
@@ -1217,6 +1220,19 @@ function buildReverseCondition(condition: string): string | null {
 			case 'NEUTRAL':
 				conditions.push("refCard.classes?.includes('NEUTRAL')");
 				break;
+			case 'PROTOSS':
+				conditions.push("refCard.mechanics?.includes('PROTOSS')");
+				break;
+			case 'ZERG':
+				conditions.push("refCard.mechanics?.includes('ZERG')");
+				break;
+			case 'TERRAN':
+				conditions.push("refCard.mechanics?.includes('TERRAN')");
+				break;
+			case 'TEMPLAR':
+				// Templar is a specific card check, not a mechanic - skip for reverse selectors
+				// as it's not a property that can be checked on any card
+				return null;
 			default:
 				if (part.startsWith('COST_MORE_')) {
 					const value = part.replace('COST_MORE_', '');


### PR DESCRIPTION
Enable reverse selectors for Protoss, Zerg, and Terran minions to highlight synergy cards.

Previously, hovering over Starcraft minions (e.g., High Templar) did not correctly light up cards that synergize with their race (e.g., Blink, Warp Gate). This was due to missing logic in `build-reverse-mappings.ts` to check for `PROTOSS`, `ZERG`, or `TERRAN` mechanics, which has now been added and the selector files regenerated.

---
<a href="https://cursor.com/background-agent?bcId=bc-3e41272a-1b70-48f7-8075-969152f7bf30"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-3e41272a-1b70-48f7-8075-969152f7bf30"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enables reverse synergy highlighting for Starcraft mechanics.
> 
> - Extends minion condition filtering to include `PROTOSS`, `ZERG`, and `TERRAN`
> - Updates `buildReverseCondition(...)` to check `refCard.mechanics` for these mechanics and ignores `TEMPLAR`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 70faacbc84eaaeb3d4f6705e958c78fcc8b7561b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->